### PR TITLE
Compile csharp proto without grpc plugin

### DIFF
--- a/dotnet-core/Dockerfile
+++ b/dotnet-core/Dockerfile
@@ -1,0 +1,5 @@
+FROM namely/protoc
+MAINTAINER Core Services <coreservices@namely.com>
+
+COPY script.sh /opt/namely/script.sh
+ENTRYPOINT ["/opt/namely/script.sh"]

--- a/dotnet-core/script.sh
+++ b/dotnet-core/script.sh
@@ -1,0 +1,24 @@
+#!/bin/bash
+
+set -e
+
+TARGET_DIR="pb-csharp"
+
+pf=(`find . -maxdepth 1 -name "*.proto"`)
+if [ ${#pf[*]} -eq 0 ]; then
+  echo "No proto files found!"
+  exit 1
+fi
+
+echo "Found Proto definitions:"
+printf "\t+%s\n" "${pf[@]}"
+
+echo
+
+if [ ! -d "$TARGET_DIR" ]; then
+  mkdir $TARGET_DIR
+fi
+
+echo "Building csharp..."
+protoc -I . ${pf[@]} --csharp_out=./$TARGET_DIR
+echo "Done"


### PR DESCRIPTION
grpc is not _yet_ available for dotnet core, so [our dotnet core app](https://github.com/namely/Namely.Payroll.Data) needs to use a [protobuf-only protoc](https://github.com/google/protobuf) instead of a [grpc-friendly protoc](https://github.com/grpc/grpc/tree/master/src/csharp).

TODO:
- [x] Build a docker image that exposes a protobuf-only protoc
- [ ] Push image to our registry

To better explain the difference, here's the git diff of some code I'm generating from a proto file I have.

```
+        errorMessage_ = pb::Preconditions.CheckNotNull(value, "value");
-        errorMessage_ = pb::ProtoPreconditions.CheckNotNull(value, "value");

```

The `-` part of this is the generated code with the grpc mixins, the `+` part is without it.
