### PR TITLE
Python 1.1 and using python grpcio-tools package

### DIFF
--- a/python/Dockerfile
+++ b/python/Dockerfile
@@ -1,39 +1,13 @@
-FROM namely/protoc
+FROM python:3.5
 MAINTAINER Core Services <coreservices@namely.com>
 
-ENV GRPC_RELEASE v1.0.x
+ENV GRPC_RELEASE v1.1.0
 
 # Install protoc python generator
 ###################################
+RUN pip install grpcio-tools==$GRPC_RELEASE
 
-RUN set -ex \
-	&& apk --no-cache --update add --virtual .python-builder \
-  git \
-  gcc \
-  g++ \
-  openssl \
-  make \
-	cmake \
-  autoconf \
-  automake \
-  libtool \
-  \
-  && mkdir -p /usr/local/grpc \
-  && git clone https://github.com/grpc/grpc.git /usr/local/grpc \
-  \
-  && cd /usr/local/grpc \
-  && git checkout $GRPC_RELEASE \
-  && git submodule update --init \
-  \
-  && cd /usr/local/grpc \
-  && make grpc_python_plugin \
-  \
-  && mkdir -p /opt/namely \
-  && cp /usr/local/grpc/bins/opt/grpc_python_plugin /opt/namely \
-  && apk del .python-builder \
-	&& rm -rf /var/cache/apk/* \
-  && rm -rf /usr/local/grpc \
-  && rm -rf /usr/local/include
+WORKDIR /defs
 
 COPY script.sh /opt/namely/script.sh
 ENTRYPOINT ["/opt/namely/script.sh"]

--- a/python/script.sh
+++ b/python/script.sh
@@ -20,5 +20,5 @@ if [ ! -d "$TARGET_DIR" ]; then
 fi
 
 echo "Building Python..."
-protoc -I . ${pf[@]} --python_out=./$TARGET_DIR --grpc_out=./$TARGET_DIR --plugin=protoc-gen-grpc=/opt/namely/grpc_python_plugin
+python -m grpc.tools.protoc -I . --python_out=./$TARGET_DIR --grpc_python_out=./$TARGET_DIR ${pf[@]}
 echo "Done"


### PR DESCRIPTION
`grpcio-tools` is available on pypi simplifying the setup for compiling protobuf files for python.

The PR is also switching the `grpc` lib (for python) to 1.1, which is the latest stable version atm. 