### PR TITLE
Update protoc to 3.4 and grpc in the Go container

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -18,7 +18,7 @@ RUN set -ex \
   \
 	&& mkdir -p /tmp/protobufs \
 	&& cd /tmp/protobufs \
-	&& curl -o protobufs.tar.gz -L https://github.com/google/protobuf/releases/download/v3.0.0/protobuf-cpp-3.0.0.tar.gz \
+	&& curl -o protobufs.tar.gz -L https://github.com/google/protobuf/releases/download/v3.4.1/protobuf-cpp-3.4.1.tar.gz \
 	&& mkdir -p protobuf \
 	&& tar -zxvf protobufs.tar.gz -C /tmp/protobufs/protobuf --strip-components=1 \
 	&& cd protobuf \
@@ -29,10 +29,18 @@ RUN set -ex \
   && cd \
 	&& rm -rf /tmp/protobufs/ \
   && rm -rf /tmp/protobufs.tar.gz \
-	&& apk --no-cache add libstdc++ \ 
+	&& apk --no-cache add libstdc++ \
 	&& apk del .pb-build \
 	&& rm -rf /var/cache/apk/* \
 	&& mkdir /defs
 
-# Setup directories for the volumes that should be used
+RUN apk add --update git
+
+# Clone in additional google API's protocol buffer definitions
+# so every project can use definitions such as google.rpc.Status
+WORKDIR /usr/include
+RUN git clone https://github.com/googleapis/googleapis.git
+
+# Change the working directory to where all definitions are expected to
+# be mounted into
 WORKDIR /defs

--- a/go/Dockerfile
+++ b/go/Dockerfile
@@ -1,57 +1,12 @@
 FROM namely/protoc
 MAINTAINER Core Services <coreservices@namely.com>
 
-ENV GO_VERSION 1.6.2
-ENV GO_SRC_URL http://golang.org/dl/go$GO_VERSION.src.tar.gz
-ENV GO_SRC_SHA1 787b0b750d037016a30c6ed05a8a70a91b2e9db4bd9b1a2453aa502a63f1bccc
-
-ENV GO_BOOTSTRAP_VERSION 1.4.3
-ENV GO_BOOTSTRAP_URL http://storage.googleapis.com/golang/go$GO_BOOTSTRAP_VERSION.src.tar.gz
-ENV GO_BOOTSTRAP_SHA1 486db10dc571a55c8d795365070f66d343458c48
-
-ENV CGO_ENABLED 0
-
-# Install protoc go generator
-###################################
+RUN apk add --update go
 RUN mkdir -p /go
 ENV GOPATH /go
-ENV PATH $GOPATH/bin:/usr/local/go/bin:$PATH
+RUN go get -a github.com/golang/protobuf/protoc-gen-go
 
-RUN set -ex \
-	&& apk --no-cache add --virtual .scm \
-  bash \
-  musl-dev \
-  git \
-  gcc \
-	openssl \
-  binutils \
-  build-base \
-	&& mkdir -p /usr/local/bootstrap \
-	&& wget -q "$GO_BOOTSTRAP_URL" -O golang.tar.gz \
-	&& echo "$GO_BOOTSTRAP_SHA1  golang.tar.gz" | sha1sum -c - \
-	&& tar -C /usr/local/bootstrap -xzf golang.tar.gz \
-	&& rm golang.tar.gz \
-	&& cd /usr/local/bootstrap/go/src \
-	&& ./make.bash \
-	&& export GOROOT_BOOTSTRAP=/usr/local/bootstrap/go \
-	\
-	&& wget -q "$GO_SRC_URL" -O golang.tar.gz \
-	&& echo "$GO_SRC_SHA1  golang.tar.gz" | sha256sum -c - \
-	&& tar -C /usr/local -xzf golang.tar.gz \
-	&& rm golang.tar.gz \
-	&& cd /usr/local/go/src \
-	&& ./make.bash \
-  \
-  && mkdir -p "$GOPATH/src" "$GOPATH/bin" \
-  && chmod -R 777 "$GOPATH" \
-	\
-	&& go get -a github.com/golang/protobuf/protoc-gen-go \
-	\
-  && apk del .scm \
-	&& rm -rf /usr/local/bootstrap \
-  && rm -rf /var/cache/apk/* \
-  && rm -rf /usr/local/go \
-  && rm -rf "$GOPATH/src"
+ENV PATH $PATH:/go/bin
 
 COPY script.sh /opt/namely/script.sh
 ENTRYPOINT ["/opt/namely/script.sh"]


### PR DESCRIPTION
This updates the Protocol Buffer compiler to use 3.4.1.  It also includes the standard Google API's protobuf definitions in the include path. This allows you to import definitions such as:

```proto
import "googleapis/google/rpc/status.proto";
```

Includes an update to the Go container to use the latest version of the gRPC generator.