### PR TITLE
Support proto-discovery within a directory for all container

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,10 @@
 # Protocol Buffer Compiler Containers
 
-This repository contains the Dockerfile for generating gRPC and protobuf
-code for various languages, removing the need to setup protoc and the
-various gRPC plugins lcoally. It relies on setting a simple volume to the 
-docker container, usually mapping the current directory to `/defs`,
-and specifying the file and language you want to generate. 
+This repository contains the Dockerfile for generating gRPC and protobuf code
+for various languages, removing the need to setup protoc and the various gRPC
+plugins lcoally. It relies on setting a simple volume to the docker container,
+usually mapping the current directory to `/defs`, and specifying the file and
+language you want to generate.
 
 ## Usage
 
@@ -14,8 +14,8 @@ Pull the container:
 $ docker pull namely/protoc-all
 ```
 
-After that, travel to the directory that contains your `.proto` definition files.
-
+After that, travel to the directory that contains your `.proto` definition
+files.
 
 So if you have a directory: `/Users/me/project/protobufs/` that has:
 `myproto.proto`, you'd want to do this:
@@ -25,17 +25,25 @@ cd ~/my_project/protobufs
 docker run -v `pwd`:/defs namely/protoc-all -f myproto.proto -l ruby #or go, csharp, etc
 ```
 
-The container automatically puts the compiled files into a `gen` directory with language-specific sub-directories. So
-for Golang, the files go into a directory `./gen/pb-go`; For ruby the directory is `./gen/pb-ruby`.
+The container automatically puts the compiled files into a `gen` directory with
+language-specific sub-directories. So for Golang, the files go into a directory
+`./gen/pb-go`; For ruby the directory is `./gen/pb-ruby`.
 
 ## Options
 
-You can use the `-o` flag to specify an output directory. This will automatically be created. For example, add `-o my-gen` to
-add all fileoutput to the `my-gen` directory. In this case, `pb-*` subdirectories will not be created.
+You can use the `-o` flag to specify an output directory. This will
+automatically be created. For example, add `-o my-gen` to add all fileoutput to
+the `my-gen` directory. In this case, `pb-*` subdirectories will not be created.
 
-You can also use `-i` to add extra include directories. This can be helpful to *lift* protofiles up a directory when generating.
-As an example, say you have a file `protorepo/catalog/catalog.proto`. This will by default output to `gen/pb-go/protorepo/catalog/` because `protorepo` is part of the file path input. To remove the `protorepo` you need to add an
-include and change the import:
+You can use the `-d` flag to generate all proto files in a directory. You cannot
+use this with the `-f` option.
+
+You can also use `-i` to add extra include directories. This can be helpful to
+_lift_ protofiles up a directory when generating. As an example, say you have a
+file `protorepo/catalog/catalog.proto`. This will by default output to
+`gen/pb-go/protorepo/catalog/` because `protorepo` is part of the file path
+input. To remove the `protorepo` you need to add an include and change the
+import:
 
 ```
 $ docker run ... namely/protoc-all -i protorepo -f catalog/catalog.proto -l go
@@ -46,9 +54,10 @@ $ docker run ... namely/protoc-all -f protorepo/catalog/catalog.proto -l go
 
 ## gRPC Gateway (Experimental)
 
-You can optionally specify `--with-gateway` to generate [grpc-gateway](https://github.com/grpc-ecosystem/grpc-gateway) support with
-swagger. Ideally this will generate a ready-to-go containerized app, but for now you can access the generated
-gateway code and swagger definition.
+You can optionally specify `--with-gateway` to generate
+[grpc-gateway](https://github.com/grpc-ecosystem/grpc-gateway) support with
+swagger. Ideally this will generate a ready-to-go containerized app, but for now
+you can access the generated gateway code and swagger definition.
 
 ## Contributing
 

--- a/test.sh
+++ b/test.sh
@@ -7,10 +7,14 @@ docker build -t namely/test-protoc-all ./all
 # Generate proto files
 for lang in ${LANGS[@]}; do
     echo "Testing language $lang"
-    docker run --rm -v=`pwd`:/defs namely/test-protoc-all -f test.proto -l $lang
+    docker run --rm -v=`pwd`:/defs namely/test-protoc-all -f test/test.proto -l $lang -i test
+    docker run --rm -v=`pwd`:/defs namely/test-protoc-all -d test -l $lang -o gen/dir/$lang --with-gateway
     if [[ ! -d gen/pb-$lang ]]; then
         echo "generated directory does not exist"
         exit 1
     fi
+    if [[ ! -d gen/dir/$lang ]]; then
+        echo "generated directory for all-file include method does not exist"
+        exit 1
+    fi
 done
-

--- a/test/include.proto
+++ b/test/include.proto
@@ -1,0 +1,9 @@
+syntax = "proto3";
+
+package Messages;
+
+message ListMessageResponse {
+    repeated string messages = 1;
+}
+
+  

--- a/test/test.proto
+++ b/test/test.proto
@@ -3,6 +3,7 @@ syntax = "proto3";
 package Messages;
 
 import "google/api/annotations.proto";
+import "include.proto";
 
 service Message {
   rpc ListMessage (ListMessageRequest) returns (ListMessageResponse) {
@@ -14,9 +15,5 @@ service Message {
 
 message ListMessageRequest {
   string query = 1;
-}
-
-message ListMessageResponse {
-  repeated string messages = 1;
 }
 

--- a/test/test.proto
+++ b/test/test.proto
@@ -16,4 +16,3 @@ service Message {
 message ListMessageRequest {
   string query = 1;
 }
-


### PR DESCRIPTION
The previous protoc-all container only supported a single proto input file. This method supports a directory option, which will generate code for all proto files in a directory (one level only), with gateway support.  