### PR TITLE
Fixes to grpc-gateway generation

### DIFF
--- a/all/entrypoint.sh
+++ b/all/entrypoint.sh
@@ -101,6 +101,11 @@ if [[ ! ${SUPPORTED_LANGUAGES[*]} =~ "$GEN_LANG" ]]; then
     exit 1
 fi
 
+if [[ "$GEN_GATEWAY" == true && "$GEN_LANG" != "go" ]]; then
+	echo "Generating grpc-gateway is Go specific."
+	exit 1
+fi
+
 PLUGIN_LANG=$GEN_LANG
 if [ $PLUGIN_LANG == 'objc' ] ; then
     PLUGIN_LANG='objective_c'
@@ -146,7 +151,7 @@ protoc $PROTO_INCLUDE \
     ${PROTO_FILES[@]}
 
 if [ $GEN_GATEWAY = true ]; then
-    GATEWAY_DIR=${OUT_DIR}/gateway
+    GATEWAY_DIR=${OUT_DIR}
     mkdir -p ${GATEWAY_DIR}
 
     protoc $PROTO_INCLUDE \

--- a/all/entrypoint.sh
+++ b/all/entrypoint.sh
@@ -115,7 +115,7 @@ if [[ $OUT_DIR == '' ]]; then
     OUT_DIR="${GEN_DIR}/pb-$GEN_LANG"
 fi
 
-echo "Generting $GEN_LANG files for ${FILE}${PROTO_DIR} in $OUT_DIR"
+echo "Generating $GEN_LANG files for ${FILE}${PROTO_DIR} in $OUT_DIR"
 
 if [[ ! -d $OUT_DIR ]]; then
   mkdir -p $OUT_DIR

--- a/all/entrypoint.sh
+++ b/all/entrypoint.sh
@@ -102,8 +102,8 @@ if [[ ! ${SUPPORTED_LANGUAGES[*]} =~ "$GEN_LANG" ]]; then
 fi
 
 if [[ "$GEN_GATEWAY" == true && "$GEN_LANG" != "go" ]]; then
-	echo "Generating grpc-gateway is Go specific."
-	exit 1
+  echo "Generating grpc-gateway is Go specific."
+  exit 1
 fi
 
 PLUGIN_LANG=$GEN_LANG

--- a/test.sh
+++ b/test.sh
@@ -8,7 +8,10 @@ docker build -t namely/test-protoc-all ./all
 for lang in ${LANGS[@]}; do
     echo "Testing language $lang"
     docker run --rm -v=`pwd`:/defs namely/test-protoc-all -f test/test.proto -l $lang -i test
-    docker run --rm -v=`pwd`:/defs namely/test-protoc-all -d test -l $lang -o gen/dir/$lang --with-gateway
+		if [[ "$lang" == "go" ]]; then
+    	docker run --rm -v=`pwd`:/defs namely/test-protoc-all -d test -l $lang -o gen/dir/$lang --with-gateway
+		fi
+
     if [[ ! -d gen/pb-$lang ]]; then
         echo "generated directory does not exist"
         exit 1

--- a/test.sh
+++ b/test.sh
@@ -8,9 +8,9 @@ docker build -t namely/test-protoc-all ./all
 for lang in ${LANGS[@]}; do
     echo "Testing language $lang"
     docker run --rm -v=`pwd`:/defs namely/test-protoc-all -f test/test.proto -l $lang -i test
-		if [[ "$lang" == "go" ]]; then
-    	docker run --rm -v=`pwd`:/defs namely/test-protoc-all -d test -l $lang -o gen/dir/$lang --with-gateway
-		fi
+    if [[ "$lang" == "go" ]]; then
+      docker run --rm -v=`pwd`:/defs namely/test-protoc-all -d test -l $lang -o gen/dir/$lang --with-gateway
+    fi
 
     if [[ ! -d gen/pb-$lang ]]; then
         echo "generated directory does not exist"

--- a/test.sh
+++ b/test.sh
@@ -2,22 +2,29 @@
 
 LANGS=("go" "ruby" "csharp" "java" "python" "objc")
 
+# Checks that directories were appropriately created, and deletes the generated directory.
+testGeneration() {
+  lang=$1
+  extra_arg=$2
+  echo "Testing language $lang $extra_arg"
+
+  docker run --rm -v=`pwd`:/defs namely/test-protoc-all -f test/test.proto -l $lang -i test $extra_arg
+
+  if [[ ! -d "gen/pb-$lang" ]]; then
+      echo "generated directory does not exist"
+      exit 1
+  fi
+  echo "Passed!"
+
+  rm -rf gen/
+}
+
 docker build -t namely/test-protoc-all ./all
+
+# Test grpc-gateway generation.
+testGeneration go --with-gateway
 
 # Generate proto files
 for lang in ${LANGS[@]}; do
-    echo "Testing language $lang"
-    docker run --rm -v=`pwd`:/defs namely/test-protoc-all -f test/test.proto -l $lang -i test
-    if [[ "$lang" == "go" ]]; then
-      docker run --rm -v=`pwd`:/defs namely/test-protoc-all -d test -l $lang -o gen/dir/$lang --with-gateway
-    fi
-
-    if [[ ! -d gen/pb-$lang ]]; then
-        echo "generated directory does not exist"
-        exit 1
-    fi
-    if [[ ! -d gen/dir/$lang ]]; then
-        echo "generated directory for all-file include method does not exist"
-        exit 1
-    fi
+    testGeneration "$lang"
 done

--- a/test.sh
+++ b/test.sh
@@ -8,15 +8,23 @@ testGeneration() {
   extra_arg=$2
   echo "Testing language $lang $extra_arg"
 
+  # Test calling a file directly.
   docker run --rm -v=`pwd`:/defs namely/test-protoc-all -f test/test.proto -l $lang -i test $extra_arg
-
   if [[ ! -d "gen/pb-$lang" ]]; then
       echo "generated directory does not exist"
       exit 1
   fi
-  echo "Passed!"
-
   rm -rf gen/
+
+  # Test scanning a dir.
+  docker run --rm -v=`pwd`:/defs namely/test-protoc-all -d test -l $lang -o gen/dir/$lang $extra_arg
+  if [[ ! -d gen/dir/$lang ]]; then
+    echo "generated directory for all-file include method does not exist"
+    exit 1
+  fi
+  rm -rf gen/
+
+  echo "Passed!"
 }
 
 docker build -t namely/test-protoc-all ./all


### PR DESCRIPTION
grpc-gateway generation is now golang specific.

gateway files are generated in the same directory as the protobufs, which is required for imports to work.