### PR TITLE
Add support to generate nodejs output.

### DIFF
--- a/all/entrypoint.sh
+++ b/all/entrypoint.sh
@@ -144,7 +144,6 @@ case $GEN_LANG in
         GEN_STRING="--grpc_out=$OUT_DIR --${GEN_LANG}_out=$OUT_DIR --plugin=protoc-gen-grpc=`which protoc-gen-grpc-java`"
         ;;
     "node")
-        SERVICE_NAME=$(basename $PROTO_DIR)
         GEN_STRING="--grpc_out=$OUT_DIR --js_out=import_style=commonjs,binary:$OUT_DIR --plugin=protoc-gen-grpc=`which grpc_${PLUGIN_LANG}_plugin`"
         ;;
     *)

--- a/all/entrypoint.sh
+++ b/all/entrypoint.sh
@@ -19,7 +19,7 @@ printUsage() {
 }
 
 GEN_GATEWAY=false
-SUPPORTED_LANGUAGES=("go" "ruby" "csharp" "java" "python" "objc")
+SUPPORTED_LANGUAGES=("go" "ruby" "csharp" "java" "python" "objc" "node")
 EXTRA_INCLUDES=""
 OUT_DIR=""
 
@@ -142,6 +142,10 @@ case $GEN_LANG in
         ;;
     "java")
         GEN_STRING="--grpc_out=$OUT_DIR --${GEN_LANG}_out=$OUT_DIR --plugin=protoc-gen-grpc=`which protoc-gen-grpc-java`"
+        ;;
+    "node")
+        SERVICE_NAME=$(basename $PROTO_DIR)
+        GEN_STRING="--grpc_out=$OUT_DIR --js_out=import_style=commonjs,binary:$OUT_DIR --plugin=protoc-gen-grpc=`which grpc_${PLUGIN_LANG}_plugin`"
         ;;
     *)
         GEN_STRING="--grpc_out=$OUT_DIR --${GEN_LANG}_out=$OUT_DIR --plugin=protoc-gen-grpc=`which grpc_${PLUGIN_LANG}_plugin`"

--- a/all/test.sh
+++ b/all/test.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-LANGS=("go" "ruby" "csharp" "java" "python" "objc")
+LANGS=("go" "ruby" "csharp" "java" "python" "objc" "node")
 
 CONTAINER=$1
 


### PR DESCRIPTION
The node grpc plugin currently has a hard coded assumption that the message file
to go with a certain service file is "../foo/foo_pb.js". This is not always the
case, but for now we try to ensure the --js_out argument is set to match what
the grpc plugin expects.