### PR TITLE
Allow running gateway under directory.

### DIFF
--- a/gwy/templates/config.yaml.tmpl
+++ b/gwy/templates/config.yaml.tmpl
@@ -4,6 +4,7 @@ cors:
   allow-credentials:
 proxy:
   port: 80
+  api-prefix: "/"
 swagger:
   file: "${SWAGGER_FILE_NAME}"
 

--- a/gwy/templates/main.go.tmpl
+++ b/gwy/templates/main.go.tmpl
@@ -44,11 +44,8 @@ func allowCors(cfg proxyConfig, handler http.Handler) http.Handler {
 
 // sanitizeApiPrefix forces prefix to be non-empty and end with a slash.
 func sanitizeApiPrefix(prefix string) string {
-  if len(prefix) == 0 {
-    prefix = "/"
-  }
-  if prefix[len(prefix)-1:] != "/" {
-    prefix = prefix + "/"
+  if len(prefix) == 0 || prefix[len(prefix)-1:] != "/" {
+    return prefix + "/"
   }
   return prefix
 }

--- a/gwy/templates/main.go.tmpl
+++ b/gwy/templates/main.go.tmpl
@@ -20,10 +20,18 @@ import (
 )
 
 type proxyConfig struct {
-  backend string
-  swagger string
+  // The backend gRPC service to listen to.
+  backend              string
+  // Path to the swagger file to serve.
+  swagger              string
+  // Value to set for Access-Control-Allow-Origin header.
   corsAllowOrigin      string
+  // Value to set for Access-Control-Allow-Credentials header.
   corsAllowCredentials string
+  // Prefix that this gateway is running on. For example, if your API endpoint
+  // was "/foo/bar" in your protofile, and you wanted to run APIs under "/api",
+  // set this to "/api/".
+  apiPrefix            string
 }
 
 func allowCors(cfg proxyConfig, handler http.Handler) http.Handler {
@@ -32,6 +40,17 @@ func allowCors(cfg proxyConfig, handler http.Handler) http.Handler {
     w.Header().Set("Access-Control-Allow-Credentials", cfg.corsAllowCredentials)
     handler.ServeHTTP(w, req)
   })
+}
+
+// sanitizeApiPrefix forces prefix to be non-empty and end with a slash.
+func sanitizeApiPrefix(prefix string) string {
+  if len(prefix) == 0 {
+    prefix = "/"
+  }
+  if prefix[len(prefix)-1:] != "/" {
+    prefix = prefix + "/"
+  }
+  return prefix
 }
 
 func SetupMux(ctx context.Context, cfg proxyConfig) *http.ServeMux {
@@ -49,7 +68,10 @@ func SetupMux(ctx context.Context, cfg proxyConfig) *http.ServeMux {
   if err != nil {
     log.Fatalf("Could not register gateway: %v", err)
   }
-  mux.Handle("/", allowCors(cfg, gwmux))
+
+	prefix := sanitizeApiPrefix(cfg.apiPrefix)
+	log.Println("API prefix is", prefix)
+	mux.Handle(prefix, http.StripPrefix(prefix[:len(prefix)-1], allowCors(cfg, gwmux)))
   return mux
 }
 
@@ -100,10 +122,11 @@ func main() {
   defer cancel()
 
   mux := SetupMux(ctx, proxyConfig{
-    backend: cfg.GetString("backend"),
-    swagger: cfg.GetString("swagger.file"),
+    backend:              cfg.GetString("backend"),
+    swagger:              cfg.GetString("swagger.file"),
     corsAllowOrigin:      cfg.GetString("cors.allow-origin"),
     corsAllowCredentials: cfg.GetString("cors.allow-credentials"),
+    apiPrefix:            cfg.GetString("proxy.api-prefix"),
   })
 
   addr := fmt.Sprintf(":%v", cfg.GetInt("proxy.port"))

--- a/gwy/templates/main.go.tmpl
+++ b/gwy/templates/main.go.tmpl
@@ -69,9 +69,9 @@ func SetupMux(ctx context.Context, cfg proxyConfig) *http.ServeMux {
     log.Fatalf("Could not register gateway: %v", err)
   }
 
-	prefix := sanitizeApiPrefix(cfg.apiPrefix)
-	log.Println("API prefix is", prefix)
-	mux.Handle(prefix, http.StripPrefix(prefix[:len(prefix)-1], allowCors(cfg, gwmux)))
+  prefix := sanitizeApiPrefix(cfg.apiPrefix)
+  log.Println("API prefix is", prefix)
+  mux.Handle(prefix, http.StripPrefix(prefix[:len(prefix)-1], allowCors(cfg, gwmux)))
   return mux
 }
 

--- a/gwy/test.sh
+++ b/gwy/test.sh
@@ -1,4 +1,6 @@
 #!/bin/bash
+set -e
+set -x
 
 CONTAINER=$1
 
@@ -7,4 +9,36 @@ docker run --rm -v=`pwd`:/defs $CONTAINER -f test/test.proto -s Message
 
 # And make sure that we can build the test gateway too.
 docker build -t $CONTAINER-test-gateway gen/grpc-gateway/
+
+# Now run the test container with a prefix in the background
+docker run -p=8080:80 -e 'MESSAGE_PROXY_API-PREFIX=/api/' $CONTAINER-test-gateway &
+
+# Give it a few to start accepting requests
+sleep 5
+
+# Now use curl to make sure we get an expected status.
+# From https://superuser.com/a/442395
+status=`curl -s -o /dev/null -w "%{http_code}" localhost:8080/api/messages`
+
+# For now, we expect a 503 service unavailable, since we don't have a grpc service
+# running. In the future, if this was a real backend we should get a 200. However,
+# here we can use the 503 to indicate that the gateway tried to send the request
+# downstream.
+if [ "$status" -ne "503" ]; then
+  kill $1
+  echo "Invalid status: '$status'"
+  exit 1
+fi
+
+# If we call an endpoint that does not exist (say just messages), we should
+# get a 404, since there's no handler for that endpoint.
+status=`curl -s -o /dev/null -w "%{http_code}" localhost:8080/messages`
+if [ "$status" -ne "404" ]; then
+  kill $1
+  echo "Invalid status: '$status'"
+  exit 1
+fi
+
+kill $!
+
 

--- a/gwy/test.sh
+++ b/gwy/test.sh
@@ -25,7 +25,7 @@ status=`curl -s -o /dev/null -w "%{http_code}" localhost:8080/api/messages`
 # here we can use the 503 to indicate that the gateway tried to send the request
 # downstream.
 if [ "$status" -ne "503" ]; then
-  kill $1
+  kill $!
   echo "Invalid status: '$status'"
   exit 1
 fi
@@ -34,7 +34,7 @@ fi
 # get a 404, since there's no handler for that endpoint.
 status=`curl -s -o /dev/null -w "%{http_code}" localhost:8080/messages`
 if [ "$status" -ne "404" ]; then
-  kill $1
+  kill $!
   echo "Invalid status: '$status'"
   exit 1
 fi


### PR DESCRIPTION
By specifying proxy.api-prefix, you can have the gateway strip prefixes.

For example, suppose that you have a proto file with the following:

```
option (google.api.http) = {
  get: "/v1alpha1/fun"
};
```

If you wanted people to access it at https://example.com/api/v1alpha1/fun you would specify proxy.api-prefix=/api/, and the gateway will do the rest.

Fixes #56 