### PR TITLE
Forward all headers, not just those starting with Grpc-Gateway-

### DIFF
--- a/gwy/Dockerfile
+++ b/gwy/Dockerfile
@@ -1,4 +1,4 @@
-FROM namely/protoc-all
+FROM namely/protoc-all:1.10
 
 COPY templates /templates
 COPY generate_gateway.sh /usr/local/bin

--- a/gwy/templates/main.go.tmpl
+++ b/gwy/templates/main.go.tmpl
@@ -5,6 +5,7 @@ import (
   "fmt"
   "log"
   "net/http"
+  "net/textproto"
   "os"
   "os/signal"
   "strings"
@@ -50,6 +51,20 @@ func sanitizeApiPrefix(prefix string) string {
   return prefix
 }
 
+// incomingHeaderMatcher converts an HTTP header name on http.Request to
+// grpc metadata. We prepend incoming headers with grpcgateway- to avoid
+// collisions with reserved metadata names.
+func incomingHeaderMatcher(key string) (string, bool) {
+  key = textproto.CanonicalMIMEHeaderKey(key)
+  return runtime.MetadataPrefix + key, true
+}
+
+// outgoingHeaderMatcher transforms outgoing metadata into HTTP headers.
+// We return any response metadata as is.
+func outgoingHeaderMatcher(metadata string) (string, bool) {
+  return metadata, true
+}
+
 func SetupMux(ctx context.Context, cfg proxyConfig) *http.ServeMux {
   mux := http.NewServeMux()
 
@@ -57,10 +72,16 @@ func SetupMux(ctx context.Context, cfg proxyConfig) *http.ServeMux {
     http.ServeFile(w, r, cfg.swagger)
   })
 
-  opts := []grpc.DialOption{grpc.WithInsecure()}
-  gwmux := runtime.NewServeMux()
+  gwmux := runtime.NewServeMux(
+    runtime.WithIncomingHeaderMatcher(incomingHeaderMatcher),
+    runtime.WithOutgoingHeaderMatcher(outgoingHeaderMatcher),
+  )
   fmt.Printf("Proxying requests to gRPC service at '%s'\n", cfg.backend)
   
+  opts := []grpc.DialOption{grpc.WithInsecure()}
+  // If you get a compilation error that gw.Register${SERVICE}HandlerFromEndpoint
+  // does not exist, it's because you haven't added any google.api.http annotations
+  // to your proto. Add some!
   err := gw.Register${SERVICE}HandlerFromEndpoint(ctx, gwmux, cfg.backend, opts)
   if err != nil {
     log.Fatalf("Could not register gateway: %v", err)


### PR DESCRIPTION
The grpc-gateway now sends all headers unmodified to the downstream service as metadata, rather than only those that started with `Grpc-Gateway-`. This will break backward compatibility for anyone who was using that prefix, as the gateway would strip this prefix, however I don't think that anyone was using it yet.

Tested locally, we don't have a great way to test this programmatically yet. It's on my list!

I had the client send a new header `X-My-Header: asdf` and the server set metadata `outbound-header: foobar`, with
```
header := metadata.Pairs("outbound-header", "foobar")
grpc.SendHeader(ctx, header)
```

Client:
```
curl -iv localhost:8000/v1/shelves --header 'X-My-Header: asdf'
*   Trying ::1...
* TCP_NODELAY set
* Connected to localhost (::1) port 8000 (#0)
> GET /v1/shelves HTTP/1.1
> Host: localhost:8000
> User-Agent: curl/7.54.0
> Accept: */*
> X-My-Header: asdf
>
< HTTP/1.1 200 OK
HTTP/1.1 200 OK
< Access-Control-Allow-Credentials:
Access-Control-Allow-Credentials:
< Access-Control-Allow-Origin:
Access-Control-Allow-Origin:
< Content-Type: application/json
Content-Type: application/json
< Outbound-Header: foobar
Outbound-Header: foobar
< Date: Wed, 18 Apr 2018 21:51:55 GMT
Date: Wed, 18 Apr 2018 21:51:55 GMT
< Content-Length: 40
Content-Length: 40

<
* Connection #0 to host localhost left intact
{"shelves":[{"id":"2","theme":"Music"}]}%
```

Server Logs
```
{"level":"info","msg":"request metadata: map[grpcgateway-user-agent:[curl/7.54.0] grpcgateway-accept:[*/*] grpcgateway-x-my-header:[asdf] x-forwarded-host:[localhost:8000] x-forwarded-for:[172.21.0.1] :authority:[server:50051] content-type:[application/grpc] user-agent:[grpc-go/1.12.0-dev]]","time":"2018-04-18T21:43:48Z"}
```

Fixes #56 - I don't think anyone will want to configure these, so for now just forward everything.