### PR TITLE
Only prefix permanent headers and reserved headers

### DIFF
--- a/gwy/Makefile
+++ b/gwy/Makefile
@@ -1,7 +1,7 @@
 
 NAMESPACE=namely
 NAME=gen-grpc-gateway
-TAG=latest
+TAG=1.10
 CONTAINER=$(NAMESPACE)/$(NAME):$(TAG)
 
 .PHONY: build

--- a/gwy/templates/main.go.tmpl
+++ b/gwy/templates/main.go.tmpl
@@ -51,12 +51,60 @@ func sanitizeApiPrefix(prefix string) string {
   return prefix
 }
 
+// isPermanentHTTPHeader checks whether hdr belongs to the list of
+// permenant request headers maintained by IANA.
+// http://www.iana.org/assignments/message-headers/message-headers.xml
+// From https://github.com/grpc-ecosystem/grpc-gateway/blob/7a2a43655ccd9a488d423ea41a3fc723af103eda/runtime/context.go#L157
+func isPermanentHTTPHeader(hdr string) bool {
+	switch hdr {
+	case
+		"Accept",
+		"Accept-Charset",
+		"Accept-Language",
+		"Accept-Ranges",
+		"Authorization",
+		"Cache-Control",
+		"Content-Type",
+		"Cookie",
+		"Date",
+		"Expect",
+		"From",
+		"Host",
+		"If-Match",
+		"If-Modified-Since",
+		"If-None-Match",
+		"If-Schedule-Tag-Match",
+		"If-Unmodified-Since",
+		"Max-Forwards",
+		"Origin",
+		"Pragma",
+		"Referer",
+		"User-Agent",
+		"Via",
+		"Warning":
+		return true
+	}
+	return false
+}
+
+// isReserved returns whether the key is reserved by gRPC.
+func isReserved(key string) bool {
+  return strings.HasPrefix(key, "Grpc-")
+}
+
 // incomingHeaderMatcher converts an HTTP header name on http.Request to
-// grpc metadata. We prepend incoming headers with grpcgateway- to avoid
-// collisions with reserved metadata names.
+// grpc metadata. Permanent headers (i.e. User-Agent) are prepended with
+// "grpc-gateway". Headers that start with start with "Grpc-" (reserved
+// by grpc) are prepended with "X-". Other headers are forwarded as is.
 func incomingHeaderMatcher(key string) (string, bool) {
   key = textproto.CanonicalMIMEHeaderKey(key)
-  return runtime.MetadataPrefix + key, true
+  if isPermanentHTTPHeader(key) {
+    return runtime.MetadataPrefix + key, true
+  }
+  if isReserved(key) {
+    return "X-" + key, true
+  }
+  return key, true
 }
 
 // outgoingHeaderMatcher transforms outgoing metadata into HTTP headers.


### PR DESCRIPTION
This is nicer, now if you pass 'Foo', you get metadata 'foo' on the other side.

The only exceptions are:

1. Permanent headers are prefixed with grpcgateway (this is what the gateway does by default).
2. Headers starting with Grpc- are prepended with X-, since Grpc- is a reserved metadata prefix in grpc.