### PR TITLE
Expose linting

### DIFF
--- a/all/entrypoint.sh
+++ b/all/entrypoint.sh
@@ -76,7 +76,7 @@ while test $# -gt 0; do
             ;;
         --lint)
             LINT=true
-            if test $# -gt 1; then
+            if [ "$#" -gt 1 ] && [[ $2 != -* ]]; then
                 LINT_CHECKS=$2
             fi
             shift

--- a/all/entrypoint.sh
+++ b/all/entrypoint.sh
@@ -78,7 +78,7 @@ while test $# -gt 0; do
             LINT=true
             if [ "$#" -gt 1 ] && [[ $2 != -* ]]; then
                 LINT_CHECKS=$2
-		shift
+		        shift
             fi
             shift
             ;;

--- a/all/entrypoint.sh
+++ b/all/entrypoint.sh
@@ -78,6 +78,7 @@ while test $# -gt 0; do
             LINT=true
             if [ "$#" -gt 1 ] && [[ $2 != -* ]]; then
                 LINT_CHECKS=$2
+		shift
             fi
             shift
             ;;


### PR DESCRIPTION
My team is working on introducing linting of our protobufs. I noticed that `protoc-gen-lint` is being installed in the container:

https://github.com/namely/docker-protoc/blob/32cda135bca79697425b25f67f4aa69ceadfc85a/all/Dockerfile#L39

But it's not being exposed via the entrypoint. This PR adds a flag to enable linting. I've tested this on my project and it's working as I'd expect.

This is available under my dockerhub if you want to test it out:

```
blimmer/protoc-all:1.11-lint
```