### PR TITLE
Make gateway binary totally static

### DIFF
--- a/gwy/templates/Dockerfile.tmpl
+++ b/gwy/templates/Dockerfile.tmpl
@@ -13,7 +13,7 @@ RUN go get ./...
 WORKDIR /app
 
 # Build the gateway
-RUN go build -o grpc_gateway src/pkg/main/main.go
+RUN CGO_ENABLED=0 GOOS=linux go build -a -ldflags '-extldflags "-static"' -o grpc_gateway src/pkg/main/main.go
 
 FROM alpine:3.6
 WORKDIR /app


### PR DESCRIPTION
I experimenting with running this binary from the same container as my gRPC server. If that turns out to be a good idea, I need this binary to be totally static so that it works anywhere.