### PR TITLE
Upgrade grpc to 1.14

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ If you're having trouble, see [Docker troubleshooting](#docker-troubleshooting) 
 Pull the container:
 
 ```sh
-$ docker pull namely/protoc-all:1.14
+$ docker pull namely/protoc-all:1.15
 ```
 
 After that, travel to the directory that contains your `.proto` definition
@@ -28,12 +28,12 @@ So if you have a directory: `~/my_project/protobufs/` that has:
 
 ```sh
 $ cd ~/my_project/protobufs
-$ docker run -v `pwd`:/defs namely/protoc-all:1.14 -f myproto.proto -l ruby #or go, csharp, etc
+$ docker run -v `pwd`:/defs namely/protoc-all:1.15 -f myproto.proto -l ruby #or go, csharp, etc
 ```
 
 ```powershell
 PS> cd ~/my_project/protobufs
-PS> docker run -v ${pwd}:/defs namely/protoc-all:1.14 -f myproto.proto -l ruby #or go, csharp, etc
+PS> docker run -v ${pwd}:/defs namely/protoc-all:1.15 -f myproto.proto -l ruby #or go, csharp, etc
 ```
 
 The container automatically puts the compiled files into a `gen` directory with
@@ -57,9 +57,9 @@ input. To remove the `protorepo` you need to add an include and change the
 import:
 
 ```
-$ docker run ... namely/protoc-all:1.14 -i protorepo -f catalog/catalog.proto -l go
+$ docker run ... namely/protoc-all:1.15 -i protorepo -f catalog/catalog.proto -l go
 # instead of
-$ docker run ... namely/protoc-all:1.14 -f protorepo/catalog/catalog.proto -l go
+$ docker run ... namely/protoc-all:1.15 -f protorepo/catalog/catalog.proto -l go
 # which will generate files in a `protorepo` directory.
 ```
 

--- a/all/Dockerfile
+++ b/all/Dockerfile
@@ -46,6 +46,9 @@ COPY --from=build /tmp/grpc-java/compiler/build/exe/java_plugin/protoc-gen-grpc-
 COPY --from=build /tmp/googleapis/google /usr/include/google
 COPY --from=build /usr/local/include/google /usr/local/include/google
 
+RUN mkdir -p /usr/local/include/protoc-gen-swagger/options/
+RUN cp -R /go/src/github.com/grpc-ecosystem/grpc-gateway/protoc-gen-swagger/options/ /usr/local/include/protoc-gen-swagger/
+
 ADD entrypoint.sh /usr/local/bin
 RUN chmod +x /usr/local/bin/entrypoint.sh
 

--- a/all/Dockerfile
+++ b/all/Dockerfile
@@ -1,5 +1,5 @@
-ARG alpine=3.6
-ARG go=1.9.2
+ARG alpine=3.8
+ARG go=1.10.3
 
 FROM golang:$go-alpine$alpine AS build
 

--- a/all/Makefile
+++ b/all/Makefile
@@ -2,7 +2,7 @@
 DOCKER_REPO ?=
 NAMESPACE ?= namely
 NAME ?= protoc-all
-TAG ?= 1.14
+TAG ?= 1.15
 CONTAINER = $(DOCKER_REPO)$(NAMESPACE)/$(NAME):$(TAG)
 
 .PHONY: build

--- a/all/install-protobuf.sh
+++ b/all/install-protobuf.sh
@@ -1,6 +1,6 @@
 #!/bin/sh
 
-GRPC_VERSION=v1.13.x
+GRPC_VERSION=v1.14.x
 
 git clone -b $GRPC_VERSION --recursive -j8 https://github.com/grpc/grpc
 cd /tmp/grpc

--- a/gwy/Dockerfile
+++ b/gwy/Dockerfile
@@ -1,5 +1,5 @@
-ARG grpc=1.11
-FROM namely/protoc-all:$grpc
+ARG protoc_version=1.15
+FROM namely/protoc-all:$protoc_version
 
 COPY templates /templates
 COPY generate_gateway.sh /usr/local/bin

--- a/gwy/Makefile
+++ b/gwy/Makefile
@@ -1,7 +1,6 @@
-
 NAMESPACE=namely
 NAME=gen-grpc-gateway
-TAG=1.12
+TAG=1.15
 CONTAINER=$(NAMESPACE)/$(NAME):$(TAG)
 
 .PHONY: build


### PR DESCRIPTION
Also include swagger protos in include so you can easily use them in proto files.

@kaimou1357 @mdkess 

It's super weird the way we have to use swagger annotations. If they're in the proto they should be available just like the Google proto types. This includes the swagger annotations proto in the include path for proto so you can use them easier.