### PR TITLE
Import standard error details

### DIFF
--- a/gwy/templates/main.go.tmpl
+++ b/gwy/templates/main.go.tmpl
@@ -21,6 +21,7 @@ import (
 	"golang.org/x/net/context"
 	"google.golang.org/grpc"
 
+	_ "google.golang.org/genproto/googleapis/rpc/errdetails" // Pull in errdetails
 	gw "gen/pb-go"
 )
 


### PR DESCRIPTION
In order to support the standard set of status.Status error details we need to import the google.golang.org/genproto/googleapis/rpc/errdetails package.  This will cause the init() function to be called and register the types in the proto type registry