### PR TITLE
Adding option to configure response headers from env vars

### DIFF
--- a/README.md
+++ b/README.md
@@ -152,6 +152,11 @@ There are four values:
     For CORS, you will want to configure your `cors.allow-methods` to be the HTTP verbs set in your proto (i.e. `GET`, `PUT`, etc.), as well as `OPTIONS`, so that your service can handle the [preflight request](https://developer.mozilla.org/en-US/docs/Glossary/Preflight_request).
 
     If you are not using CORS, you can leave these configuration values at their default, and your gateway will not accept CORS requests.
+###  Other Response Headers
+
+You can configure additional headers to be sent in the HTTP response.  
+Set environment variable with prefix `<SERVICE>_RESPONSE-HEADERS_` (e.g `SOMESERVICE_RESPONSE-HEADERS_SOME-HEADER-KEY`).  
+You can also set headers in the your configuration file (e.g `response-headers.some-header-key`)
 
 ### Environment Variables
 

--- a/gwy/templates/main.go.tmpl
+++ b/gwy/templates/main.go.tmpl
@@ -26,6 +26,8 @@ import (
 )
 const (
 	ResponseHeaders = "RESPONSE-HEADERS"
+	EnvVarSepChar = "_"
+	ViperKeySepcChar = "."
 )
 type proxyConfig struct {
 	// The backend gRPC service to listen to.
@@ -266,9 +268,9 @@ func SetupMux(ctx context.Context, cfg proxyConfig) *http.ServeMux {
 func bindEnvVars(viper *viper.Viper, r *strings.Replacer, prefix string, secondPrefix string) {
 	for _, e := range os.Environ() {
 		pair := strings.Split(e, "=")
-		if strings.HasPrefix(pair[0], prefix+"_") {
-			key := strings.TrimPrefix(pair[0], prefix+"_")
-			if strings.HasPrefix(key, secondPrefix+"_") {
+		if strings.HasPrefix(pair[0], prefix+EnvVarSepChar) {
+			key := strings.TrimPrefix(pair[0], prefix+EnvVarSepChar)
+			if strings.HasPrefix(key, secondPrefix+EnvVarSepChar) {
 				viper.BindEnv(strings.ToLower(r.Replace(key)), pair[1])
 			}
 		}
@@ -280,7 +282,7 @@ func SetupViper() *viper.Viper {
 	viper.SetConfigName("config")
 	viper.AddConfigPath(".")
 	viper.SetEnvPrefix("${SERVICE}")
-	viper.SetEnvKeyReplacer(strings.NewReplacer(".", "_"))
+	viper.SetEnvKeyReplacer(strings.NewReplacer(ViperKeySepcChar, EnvVarSepChar))
 	viper.AutomaticEnv()
 
 	flag.String("backend", "", "The gRPC backend service to proxy.")
@@ -295,7 +297,7 @@ func SetupViper() *viper.Viper {
 	}
 
 	v := viper.GetViper()
-	bindEnvVars(v, strings.NewReplacer("_", "."), strings.ToUpper("${SERVICE}"), ResponseHeaders)
+	bindEnvVars(v, strings.NewReplacer(EnvVarSepChar, ViperKeySepcChar), strings.ToUpper("${SERVICE}"), ResponseHeaders)
 	return v
 }
 

--- a/gwy/templates/main.go.tmpl
+++ b/gwy/templates/main.go.tmpl
@@ -27,7 +27,7 @@ import (
 const (
 	ResponseHeaders = "RESPONSE-HEADERS"
 	EnvVarSepChar = "_"
-	ViperKeySepcChar = "."
+	ViperKeySepChar = "."
 )
 type proxyConfig struct {
 	// The backend gRPC service to listen to.
@@ -223,9 +223,9 @@ func getResponseHeaders(cfg *viper.Viper) map[string]string {
 	m := make(map[string]string)
 	headersPrefix := strings.ToLower(ResponseHeaders)
 	for _, key := range cfg.AllKeys() {
-		if strings.HasPrefix(key, headersPrefix+".") {
+		if strings.HasPrefix(key, headersPrefix+ViperKeySepChar) {
 			value := cfg.GetString(key)
-			header := strings.TrimPrefix(key, headersPrefix+".")
+			header := strings.TrimPrefix(key, headersPrefix+ViperKeySepChar)
 			// headers are case insensetive
 			m[header] = value
 		}
@@ -282,7 +282,7 @@ func SetupViper() *viper.Viper {
 	viper.SetConfigName("config")
 	viper.AddConfigPath(".")
 	viper.SetEnvPrefix("${SERVICE}")
-	viper.SetEnvKeyReplacer(strings.NewReplacer(ViperKeySepcChar, EnvVarSepChar))
+	viper.SetEnvKeyReplacer(strings.NewReplacer(ViperKeySepChar, EnvVarSepChar))
 	viper.AutomaticEnv()
 
 	flag.String("backend", "", "The gRPC backend service to proxy.")
@@ -297,7 +297,7 @@ func SetupViper() *viper.Viper {
 	}
 
 	v := viper.GetViper()
-	bindEnvVars(v, strings.NewReplacer(EnvVarSepChar, ViperKeySepcChar), strings.ToUpper("${SERVICE}"), ResponseHeaders)
+	bindEnvVars(v, strings.NewReplacer(EnvVarSepChar, ViperKeySepChar), strings.ToUpper("${SERVICE}"), ResponseHeaders)
 	return v
 }
 
@@ -325,8 +325,6 @@ func main() {
 	ctx, cancel := context.WithCancel(ctx)
 	defer cancel()
 	
-	responseHeaders := getResponseHeaders(cfg)
-
 	mux := SetupMux(ctx, proxyConfig{
 		backend:              cfg.GetString("backend"),
 		logLevel:             cfg.GetString("log_level"),
@@ -337,7 +335,7 @@ func main() {
 		corsAllowMethods:     cfg.GetString("cors.allow-methods"),
 		corsAllowHeaders:     cfg.GetString("cors.allow-headers"),
 		apiPrefix:            cfg.GetString("proxy.api-prefix"),
-		responseHeaders:      responseHeaders,
+		responseHeaders:      getResponseHeaders(cfg),
 	})
 
 	addr := fmt.Sprintf(":%v", cfg.GetInt("proxy.port"))

--- a/gwy/templates/main.go.tmpl
+++ b/gwy/templates/main.go.tmpl
@@ -221,9 +221,9 @@ func getResponseHeaders(cfg *viper.Viper) map[string]string {
 	m := make(map[string]string)
 	headersPrefix := strings.ToLower(ResponseHeaders)
 	for _, key := range cfg.AllKeys() {
-		if strings.HasPrefix(key, headersPrefix) {
+		if strings.HasPrefix(key, headersPrefix+".") {
 			value := cfg.GetString(key)
-			header := strings.TrimPrefix(key, headersPrefix + ".")
+			header := strings.TrimPrefix(key, headersPrefix+".")
 			// headers are case insensetive
 			m[header] = value
 		}

--- a/gwy/templates/main.go.tmpl
+++ b/gwy/templates/main.go.tmpl
@@ -24,7 +24,9 @@ import (
 	_ "google.golang.org/genproto/googleapis/rpc/errdetails" // Pull in errdetails
 	gw "gen/pb-go"
 )
-
+const (
+	ResponseHeaders = "RESPONSE-HEADERS"
+)
 type proxyConfig struct {
 	// The backend gRPC service to listen to.
 	backend string
@@ -46,6 +48,8 @@ type proxyConfig struct {
 	// was "/foo/bar" in your protofile, and you wanted to run APIs under "/api",
 	// set this to "/api/".
 	apiPrefix string
+	// map of headers to send in the http response
+	responseHeaders map[string]string
 }
 
 func logFormatter(cfg proxyConfig) handlers.LogFormatter {
@@ -110,14 +114,19 @@ func logFormatter(cfg proxyConfig) handlers.LogFormatter {
 		logrus.WithFields(fields).WithTime(params.TimeStamp).Infof("%s %s %d", params.Request.Method, uri, params.StatusCode)
 	}
 }
-
-func allowCors(cfg proxyConfig, handler http.Handler) http.Handler {
+// addRespHeaders adds any variables with the prefix `ResponseHeaders` as headers in the http response
+// as well as setting the Access-Control headers
+func addRespHeaders(cfg proxyConfig, handler http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
 		corsAllowOrigin := cfg.corsAllowOrigin
 		if corsAllowOrigin == "*" {
 			if origin := req.Header.Get("Origin"); origin != "" {
 				corsAllowOrigin = origin
 			}
+		}
+
+		for header, value := range cfg.responseHeaders {
+			w.Header().Set(header, value)	
 		}
 		w.Header().Set("Access-Control-Allow-Origin", corsAllowOrigin)
 		w.Header().Set("Access-Control-Allow-Credentials", cfg.corsAllowCredentials)
@@ -206,6 +215,21 @@ func outgoingHeaderMatcher(metadata string) (string, bool) {
 	return metadata, true
 }
 
+// getResponseHeaders will identified keys and values which are response headers settings and 
+// translate into a map
+func getResponseHeaders(cfg *viper.Viper) map[string]string {
+	m := make(map[string]string)
+	headersPrefix := strings.ToLower(ResponseHeaders)
+	for _, key := range cfg.AllKeys() {
+		if strings.HasPrefix(key, headersPrefix) {
+			value := cfg.GetString(key)
+			header := strings.TrimPrefix(key, headersPrefix + ".")
+			// headers are case insensetive
+			m[header] = value
+		}
+	}
+	return m
+}
 func SetupMux(ctx context.Context, cfg proxyConfig) *http.ServeMux {
 
 	formatter := logFormatter(cfg)
@@ -234,8 +258,21 @@ func SetupMux(ctx context.Context, cfg proxyConfig) *http.ServeMux {
 
 	prefix := sanitizeApiPrefix(cfg.apiPrefix)
 	logrus.Infof("API prefix is: %s", prefix)
-	mux.Handle(prefix, handlers.CustomLoggingHandler(os.Stdout, http.StripPrefix(prefix[:len(prefix)-1], allowCors(cfg, gwmux)), formatter))
+	mux.Handle(prefix, handlers.CustomLoggingHandler(os.Stdout, http.StripPrefix(prefix[:len(prefix)-1], addRespHeaders(cfg, gwmux)), formatter))
 	return mux
+}
+
+// bindEnvVars will bind all env vars that starts with "prefix_secondPrefix"
+func bindEnvVars(viper *viper.Viper, r *strings.Replacer, prefix string, secondPrefix string) {
+	for _, e := range os.Environ() {
+		pair := strings.Split(e, "=")
+		if strings.HasPrefix(pair[0], prefix+"_") {
+			key := strings.TrimPrefix(pair[0], prefix+"_")
+			if strings.HasPrefix(key, secondPrefix+"_") {
+				viper.BindEnv(strings.ToLower(r.Replace(key)), pair[1])
+			}
+		}
+	}
 }
 
 // SetupViper returns a viper configuration object
@@ -257,7 +294,9 @@ func SetupViper() *viper.Viper {
 		logrus.Fatalf("Could not read config: %v", err)
 	}
 
-	return viper.GetViper()
+	v := viper.GetViper()
+	bindEnvVars(v, strings.NewReplacer("_", "."), strings.ToUpper("${SERVICE}"), ResponseHeaders)
+	return v
 }
 
 // SignalRunner runs a runner function until an interrupt signal is received, at which point it
@@ -283,6 +322,8 @@ func main() {
 	ctx := context.Background()
 	ctx, cancel := context.WithCancel(ctx)
 	defer cancel()
+	
+	responseHeaders := getResponseHeaders(cfg)
 
 	mux := SetupMux(ctx, proxyConfig{
 		backend:              cfg.GetString("backend"),
@@ -294,6 +335,7 @@ func main() {
 		corsAllowMethods:     cfg.GetString("cors.allow-methods"),
 		corsAllowHeaders:     cfg.GetString("cors.allow-headers"),
 		apiPrefix:            cfg.GetString("proxy.api-prefix"),
+		responseHeaders:      responseHeaders,
 	})
 
 	addr := fmt.Sprintf(":%v", cfg.GetInt("proxy.port"))

--- a/gwy/test.sh
+++ b/gwy/test.sh
@@ -3,7 +3,8 @@ set -e
 set -x
 
 CONTAINER=$1
-
+HEADERS_FILE="./.headers"
+SOME_RESP_HEADER="SOME-RESPONSE-HEADER"
 # Test building the gateway.
 docker run --rm -v=`pwd`:/defs $CONTAINER -f test/test.proto -s Message
 
@@ -11,14 +12,14 @@ docker run --rm -v=`pwd`:/defs $CONTAINER -f test/test.proto -s Message
 docker build -t $CONTAINER-test-gateway gen/grpc-gateway/
 
 # Now run the test container with a prefix in the background
-docker run -p=8080:80 -e 'MESSAGE_PROXY_API-PREFIX=/api/' $CONTAINER-test-gateway &
+docker run -p=8080:80 -e 'MESSAGE_PROXY_API-PREFIX=/api/' -e 'MESSAGE_RESPONSE-HEADERS_'${SOME_RESP_HEADER}'=some-value' $CONTAINER-test-gateway &
 
 # Give it a few to start accepting requests
 sleep 5
 
 # Now use curl to make sure we get an expected status.
 # From https://superuser.com/a/442395
-status=`curl -s -o /dev/null -w "%{http_code}" localhost:8080/api/messages`
+status=`curl -i -s -o $HEADERS_FILE -w "%{http_code}" localhost:8080/api/messages`
 
 # For now, we expect a 503 service unavailable, since we don't have a grpc service
 # running. In the future, if this was a real backend we should get a 200. However,
@@ -30,6 +31,16 @@ if [ "$status" -ne "503" ]; then
   exit 1
 fi
 
+
+if ! grep -qi "$SOME_RESP_HEADER" "$HEADERS_FILE"; then
+  kill $!
+  echo "header $SOME_RESP_HEADER was not found in response"
+  rm $HEADERS_FILE
+  exit 1
+fi
+rm $HEADERS_FILE
+
+#curl -i -s -o './ido' localhost:8080/api/messages
 # If we call an endpoint that does not exist (say just messages), we should
 # get a 404, since there's no handler for that endpoint.
 status=`curl -s -o /dev/null -w "%{http_code}" localhost:8080/messages`


### PR DESCRIPTION
The proposed changes would enable configuring additional headers as part of each http response provided by the grpc-gateway.

It would help with [this](https://namely.atlassian.net/browse/PU-3806) bug by sending 
`Cache-Control: no-cache` in the header.
The env var set in the config map of the service would be in this case:
`ORGUNITSREADER_RESPONSE-HEADERS_CACHE-CONTROL="no-cache"`

