### PR TITLE
Removed `x` option passed to Bash in scripts causing extreme verbosity in output

### DIFF
--- a/all/entrypoint.sh
+++ b/all/entrypoint.sh
@@ -1,4 +1,4 @@
-#!/bin/bash -ex
+#!/bin/bash -e
 
 printUsage() {
     echo "gen-proto generates grpc and protobuf @ Namely"

--- a/all/install-protobuf.sh
+++ b/all/install-protobuf.sh
@@ -1,4 +1,4 @@
-#!/bin/bash -ex
+#!/bin/bash -e
 
 if [ -z $1 ]; then
     echo "You must specify a grpc version."

--- a/all/test.sh
+++ b/all/test.sh
@@ -1,4 +1,4 @@
-#!/bin/bash -ex
+#!/bin/bash -e
 
 LANGS=("go" "ruby" "csharp" "java" "python" "objc" "node" "gogo" "php" "cpp")
 
@@ -20,7 +20,7 @@ testGeneration() {
 
     # Test calling a file directly.
     docker run --rm -v=`pwd`:/defs $CONTAINER -f all/test/test.proto -l $lang -i all/test/ $extra_args
-    if [[ ! -d "$expected_output_dir" ]]; then 
+    if [[ ! -d "$expected_output_dir" ]]; then
         echo "generated directory $expected_output_dir does not exist"
         exit 1
     fi

--- a/build.sh
+++ b/build.sh
@@ -1,4 +1,4 @@
-#!/bin/bash -ex
+#!/bin/bash -e
 
 source ./variables.sh
 

--- a/push.sh
+++ b/push.sh
@@ -1,4 +1,4 @@
-#!/bin/bash -ex
+#!/bin/bash -e
 
 source ./variables.sh
 

--- a/variables.sh
+++ b/variables.sh
@@ -1,4 +1,4 @@
-#!/bin/bash -ex
+#!/bin/bash -e
 
 DOCKER_REPO=${DOCKER_REPO}
 NAMESPACE=${NAMESPACE:-namely}


### PR DESCRIPTION
The change was introduced in 34c804c3a909a667fc4b7757537b0f1f01a15aea. This has led to some seriously loud noise in our pipeline. To exit on error only the `e` option is needed, so the original goal of the aforementioned commit is still fulfilled.

We've pinned the image back to an older version (the last version that wasn't super verbose was 1.17_0 as far as I can tell).

Even things like the help output are obscured by it:

```
$ docker run --rm namely/protoc-all --help
+ GEN_GATEWAY=false
+ GEN_DOCS=false
+ DOCS_FORMAT=html,index.html
+ LINT=false
+ LINT_CHECKS=
+ SUPPORTED_LANGUAGES=("go" "ruby" "csharp" "java" "python" "objc" "gogo" "php" "node" "web" "cpp")
+ EXTRA_INCLUDES=
+ OUT_DIR=
+ GO_SOURCE_RELATIVE=
+ test 1 -gt 0
+ case "$1" in
+ printUsage
+ echo 'gen-proto generates grpc and protobuf @ Namely'
+ echo ' '
gen-proto generates grpc and protobuf @ Namely
 
Usage: gen-proto -f my-service.proto -l go
+ echo 'Usage: gen-proto -f my-service.proto -l go'
+ echo ' '
 
+ echo options:
+ echo ' -h, --help           Show help'
+ echo ' -f FILE              The proto source file to generate'
options:
 -h, --help           Show help
 -f FILE              The proto source file to generate
+ echo ' -d DIR               Scans the given directory for all proto files'
 -d DIR               Scans the given directory for all proto files
+ echo ' -l LANGUAGE          The language to generate (go' ruby csharp java python objc gogo php node web 'cpp)'
+ echo ' -o DIRECTORY         The output directory for generated files. Will be automatically created.'
 -l LANGUAGE          The language to generate (go ruby csharp java python objc gogo php node web cpp)
 -o DIRECTORY         The output directory for generated files. Will be automatically created.
+ echo ' -i includes          Extra includes'
 -i includes          Extra includes
+ echo ' --lint CHECKS        Enable linting protoc-lint (CHECKS are optional - see https://github.com/ckaznocha/protoc-gen-lint#optional-checks)'
 --lint CHECKS        Enable linting protoc-lint (CHECKS are optional - see https://github.com/ckaznocha/protoc-gen-lint#optional-checks)
+ echo ' --with-gateway       Generate grpc-gateway files (experimental).'
 --with-gateway       Generate grpc-gateway files (experimental).
 --with-docs FORMAT   Generate documentation (FORMAT is optional - see https://github.com/pseudomuto/protoc-gen-doc#invoking-the-plugin)
 --go-source-relative Make go import paths 'source_relative' - see https://github.com/golang/protobuf#parameters
+ echo ' --with-docs FORMAT   Generate documentation (FORMAT is optional - see https://github.com/pseudomuto/protoc-gen-doc#invoking-the-plugin)'
+ echo ' --go-source-relative Make go import paths '\''source_relative'\'' - see https://github.com/golang/protobuf#parameters'
+ exit 0
```

vs. 

```
$ docker run --rm namely/protoc-all:1.17_0 --help
gen-proto generates grpc and protobuf @ Namely
 
Usage: gen-proto -f my-service.proto -l go
 
options:
 -h, --help           Show help
 -f FILE              The proto source file to generate
 -d DIR               Scans the given directory for all proto files
 -l LANGUAGE          The language to generate (go ruby csharp java python objc gogo php node web cpp)
 -o DIRECTORY         The output directory for generated files. Will be automatically created.
 -i includes          Extra includes
 --lint CHECKS        Enable linting protoc-lint (CHECKS are optional - see https://github.com/ckaznocha/protoc-gen-lint#optional-checks)
 --with-gateway       Generate grpc-gateway files (experimental).
 --with-docs FORMAT   Generate documentation (FORMAT is optional - see https://github.com/pseudomuto/protoc-gen-doc#invoking-the-plugin)
 --go-source-relative Make go import paths 'source_relative' - see https://github.com/golang/protobuf#parameters
```