### PR TITLE
Add TypeScript declaration support using protoc-gen-ts plugin

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -60,7 +60,13 @@ RUN set -ex && apk --update --no-cache add \
     bash \
     libstdc++ \
     libc6-compat \
-    ca-certificates
+    ca-certificates \
+    nodejs \
+    nodejs-npm
+
+# Add TypeScript support
+
+RUN npm i -g ts-protoc-gen@0.10.0
 
 COPY --from=build /tmp/grpc/bins/opt/grpc_* /usr/local/bin/
 COPY --from=build /tmp/grpc/bins/opt/protobuf/protoc /usr/local/bin/

--- a/all/entrypoint.sh
+++ b/all/entrypoint.sh
@@ -15,6 +15,7 @@ printUsage() {
     echo " --lint CHECKS        Enable linting protoc-lint (CHECKS are optional - see https://github.com/ckaznocha/protoc-gen-lint#optional-checks)"
     echo " --with-gateway       Generate grpc-gateway files (experimental)."
     echo " --with-docs FORMAT   Generate documentation (FORMAT is optional - see https://github.com/pseudomuto/protoc-gen-doc#invoking-the-plugin)"
+    echo " --with-typescript    Generate TypeScript declaration files (.d.ts files) - see https://github.com/improbable-eng/ts-protoc-gen#readme"
     echo " --go-source-relative Make go import paths 'source_relative' - see https://github.com/golang/protobuf#parameters"
     echo " --no-google-includes Don't include Google protobufs"
 }
@@ -23,6 +24,7 @@ printUsage() {
 GEN_GATEWAY=false
 GEN_DOCS=false
 DOCS_FORMAT="html,index.html"
+GEN_TYPESCRIPT=false
 LINT=false
 LINT_CHECKS=""
 SUPPORTED_LANGUAGES=("go" "ruby" "csharp" "java" "python" "objc" "gogo" "php" "node" "web" "cpp" "descriptor_set")
@@ -87,6 +89,10 @@ while test $# -gt 0; do
             fi
             shift
             ;;
+        --with-typescript)
+            GEN_TYPESCRIPT=true
+            shift
+            ;;
         --lint)
             LINT=true
             if [ "$#" -gt 1 ] && [[ $2 != -* ]]; then
@@ -133,8 +139,13 @@ if [[ ! ${SUPPORTED_LANGUAGES[*]} =~ "$GEN_LANG" ]]; then
 fi
 
 if [[ "$GEN_GATEWAY" == true && "$GEN_LANG" != "go" ]]; then
-  echo "Generating grpc-gateway is Go specific."
-  exit 1
+    echo "Generating grpc-gateway is Go specific."
+    exit 1
+fi
+
+if [[ "$GEN_TYPESCRIPT" == true && "$GEN_LANG" != "node" ]]; then
+    echo "Generating TypeScript declaration files is Node specific."
+    exit 1
 fi
 
 PLUGIN_LANG=$GEN_LANG
@@ -198,6 +209,10 @@ esac
 if [[ $GEN_DOCS == true ]]; then
     mkdir -p $OUT_DIR/doc
     GEN_STRING="$GEN_STRING --doc_opt=$DOCS_FORMAT --doc_out=$OUT_DIR/doc"
+fi
+
+if [[ $GEN_TYPESCRIPT == true ]]; then
+    GEN_STRING="$GEN_STRING --ts_out=$OUT_DIR"
 fi
 
 LINT_STRING=''

--- a/all/test.sh
+++ b/all/test.sh
@@ -36,12 +36,23 @@ testGeneration() {
           current_path=$(dirname $current_path)
         done
     fi
+    if [[ "$extra_args" == *"--with-typescript"* ]]; then
+        # Test that we have generated the .d.ts files.
+        ts_file_count=$(find $expected_output_dir -type f -name "*.d.ts" | wc -l)
+        if [ $ts_file_count -eq 0 ]; then
+            echo ".d.ts files were not generated in $expected_output_dir"
+            exit 1
+        fi
+    fi
     rm -rf `echo $expected_output_dir | cut -d '/' -f1`
     echo "Generating for $lang passed!"
 }
 
 # Test grpc-gateway generation (only valid for Go)
 testGeneration go "gen/pb-go" --with-gateway
+
+# Test TypeScript declaration file generation (only valid for Node)
+testGeneration node "gen/pb-node" --with-typescript
 
 # Generate proto files
 for lang in ${LANGS[@]}; do


### PR DESCRIPTION
This PR is an implementation of the feature request described in https://github.com/namely/docker-protoc/issues/111:

My proposal is to add a `--with-typescript` option to the `node` language that leverages the [ts-protoc-gen](https://github.com/improbable-eng/ts-protoc-gen#readme) plugin to generate TypeScript declaration files (`.d.ts` files) that match the JavaScript output of `protoc --js_out=import_style=commonjs,binary`.

That plugin can also generate service definitions that include TypeScript declarations in the structure required by the [Improbable grpc-web implementation](https://github.com/improbable-eng/grpc-web). This PR doesn't use that feature; I thought if it would be useful to expose it as an option, maybe it would make sense as an option to the `web` language, and could be its own PR?