### PR TITLE
Update protoc-gen-grpc-web from 1.0.3 to 1.0.4

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -50,7 +50,7 @@ RUN go get -u github.com/pseudomuto/protoc-gen-doc/cmd/protoc-gen-doc
 
 # Add grpc-web support
 
-RUN curl -sSL https://github.com/grpc/grpc-web/releases/download/1.0.3/protoc-gen-grpc-web-1.0.3-linux-x86_64 \
+RUN curl -sSL https://github.com/grpc/grpc-web/releases/download/1.0.4/protoc-gen-grpc-web-1.0.4-linux-x86_64 \
     -o /tmp/grpc_web_plugin && \
     chmod +x /tmp/grpc_web_plugin
 


### PR DESCRIPTION
The new 1.0.4 version generates Typescript files slightly differently than the older version.

https://github.com/grpc/grpc-web/releases/tag/1.0.4