### PR TITLE
Update google paths in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,8 +15,13 @@ language you want to generate.
     * A custom generation script to facilitate common use-cases with `namely/protoc-all` (see below)
     * `grpc_cli` with `namely/grpc-cli`
     * [gRPC Gateway](https://github.com/grpc-ecosystem/grpc-gateway) using a custom go-based server with `namely/gen-grpc-gateway`
-* [Google APIs](https://github.com/googleapis/googleapis) included in `/usr/local/include/google`
-* [Protobuf library artificats](https://github.com/google/protobuf/tree/master/src/google/protobuf) included in `/usr/local/include/google/protobuf`
+* [Google APIs](https://github.com/googleapis/googleapis) included in `/opt/include/google`
+* [Protobuf library artificats](https://github.com/google/protobuf/tree/master/src/google/protobuf) included in `/opt/include/google/protobuf` (NOTE: `protoc` would only need part of the path i.e. `-I /opt/include` if you import WKTs like so:
+
+   ```proto
+   import "google/protobuf/empty.proto";
+   ...
+   ```
 * Support for all C based gRPC libraries with Go and Java native libraries
 
 If you're having trouble, see [Docker troubleshooting](#docker-troubleshooting) below.


### PR DESCRIPTION
I looked up the actual paths in current dockerfile, and tested with a proto which uses WKTs. The paths are no longer under `/usr`. They are under `/opt`.