### PR TITLE
Generate .d.ts files for node gRPC services

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -66,7 +66,7 @@ RUN set -ex && apk --update --no-cache add \
 
 # Add TypeScript support
 
-RUN npm i -g ts-protoc-gen@0.10.0
+RUN npm i -g ts-protoc-gen@0.11.0
 
 COPY --from=build /tmp/grpc/bins/opt/grpc_* /usr/local/bin/
 COPY --from=build /tmp/grpc/bins/opt/protobuf/protoc /usr/local/bin/

--- a/all/entrypoint.sh
+++ b/all/entrypoint.sh
@@ -250,7 +250,7 @@ if [[ $GEN_DOCS == true ]]; then
 fi
 
 if [[ $GEN_TYPESCRIPT == true ]]; then
-    GEN_STRING="$GEN_STRING --ts_out=$OUT_DIR"
+    GEN_STRING="$GEN_STRING --ts_out=service=grpc-node:$OUT_DIR"
 fi
 
 LINT_STRING=''

--- a/all/test.sh
+++ b/all/test.sh
@@ -39,7 +39,7 @@ testGeneration() {
     if [[ "$extra_args" == *"--with-typescript"* ]]; then
         # Test that we have generated the .d.ts files.
         ts_file_count=$(find $expected_output_dir -type f -name "*.d.ts" | wc -l)
-        if [ $ts_file_count -eq 0 ]; then
+        if [ $ts_file_count -ne 2 ]; then
             echo ".d.ts files were not generated in $expected_output_dir"
             exit 1
         fi


### PR DESCRIPTION
PR #125 added the `--with-typescript` option to generate .d.ts declaration files for node using the ts-protoc-gen plugin, but it didn't generate .d.ts files for gRPC services.

This PR adds support for that, fixing issue #138, by bumping the ts-protoc-gen version from 0.10.0 to 0.11.0 (which includes https://github.com/improbable-eng/ts-protoc-gen/pull/193, introducing the `service=grpc-node` option to generate those .d.ts files).