### PR TITLE
Ensure shell scripts use LF

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,2 @@
+* text=auto
+*.sh text eol=lf


### PR DESCRIPTION
Cloning this repo on Windows will corrupt the line endings without this setting.