### PR TITLE
Patch for ruby proto3 extensions

### DIFF
--- a/all/install-protobuf.sh
+++ b/all/install-protobuf.sh
@@ -29,6 +29,8 @@ make grpc_php_plugin
 cp /tmp/grpc/bins/opt/protobuf/protoc /usr/local/bin/
 
 cd /tmp/grpc/third_party/protobuf
+# Manually checkout fix for ruby proto3 extensions
+git checkout fe1790c
 make
 make install
 


### PR DESCRIPTION
Manually checkout the latest third_party/protobuf to pull in the ruby proto3 extension fix