### PR TITLE
Added support for nanopb

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,4 +3,5 @@ test.pb.go
 test.rb
 **/gen/*
 pb-*
+.idea/
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -9,6 +9,7 @@ FROM golang:$go-alpine$alpine AS build
 ARG grpc
 ARG grpc_java
 ARG grpc_web=1.0.7
+ARG nanopb=0.4.1
 
 RUN set -ex && apk --update --no-cache add \
     bash \
@@ -62,6 +63,11 @@ RUN curl -sSL https://github.com/grpc/grpc-web/releases/download/${grpc_web}/pro
     -o /tmp/grpc_web_plugin && \
     chmod +x /tmp/grpc_web_plugin
 
+RUN curl -sSL https://jpa.kapsi.fi/nanopb/download/nanopb-${nanopb}-linux-x86.tar.gz \
+    -o /tmp/nanopb.tar.gz && \
+    mkdir -p /tmp/nanopb && \
+    tar -xzf /tmp/nanopb.tar.gz --strip 1 -C /tmp/nanopb
+
 FROM alpine:3.9 AS protoc-all
 
 RUN set -ex && apk --update --no-cache add \
@@ -70,7 +76,10 @@ RUN set -ex && apk --update --no-cache add \
     libc6-compat \
     ca-certificates \
     nodejs \
-    nodejs-npm
+    nodejs-npm \
+    python \
+    py2-pip && \
+    pip install protobuf
 
 # Add TypeScript support
 
@@ -90,6 +99,9 @@ COPY --from=build /go/src/github.com/grpc-ecosystem/grpc-gateway/protoc-gen-swag
 
 COPY --from=build /go/src/github.com/envoyproxy/protoc-gen-validate/ /opt/include/
 COPY --from=build /go/src/github.com/mwitkow/go-proto-validators/ /opt/include/github.com/mwitkow/go-proto-validators/
+COPY --from=build /tmp/nanopb/generator/ /usr/local/lib/protoc-gen-nanopb/
+COPY --from=build /tmp/nanopb/generator/nanopb/ /opt/include/nanopb/options/
+COPY --from=build /tmp/nanopb/generator/proto/nanopb.proto /opt/include/nanopb/nanopb.proto
 
 ADD all/entrypoint.sh /usr/local/bin
 RUN chmod +x /usr/local/bin/entrypoint.sh

--- a/all/entrypoint.sh
+++ b/all/entrypoint.sh
@@ -40,7 +40,7 @@ DOCS_FORMAT="html,index.html"
 GEN_TYPESCRIPT=false
 LINT=false
 LINT_CHECKS=""
-SUPPORTED_LANGUAGES=("go" "ruby" "csharp" "java" "python" "objc" "gogo" "php" "node" "web" "cpp" "descriptor_set")
+SUPPORTED_LANGUAGES=("go" "ruby" "csharp" "java" "python" "objc" "gogo" "php" "node" "web" "cpp" "descriptor_set" "nanopb")
 EXTRA_INCLUDES=""
 OUT_DIR=""
 GO_SOURCE_RELATIVE=""
@@ -285,6 +285,9 @@ plugins=grpc+embedded\
         if [[ ! -z $CSHARP_OPT ]]; then
             GEN_STRING="$GEN_STRING --csharp_opt=$CSHARP_OPT"
         fi
+        ;;
+    "nanopb")
+        GEN_STRING="--nanopb_out=$OUT_DIR --plugin=protoc-gen-nanopb=/usr/local/lib/protoc-gen-nanopb/protoc-gen-nanopb"
         ;;
     *)
         GEN_STRING="--grpc_out=$OUT_DIR --${GEN_LANG}_out=$OUT_DIR --plugin=protoc-gen-grpc=`which grpc_${PLUGIN_LANG}_plugin`"


### PR DESCRIPTION
This PR adds support for nanopb protoc plugin.
https://jpa.kapsi.fi/nanopb/

Nanopb is a plain-C implementation that targets microcontrollers with tight memory constraints.