### PR TITLE
fix: prototool compile image fails with exit 127

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -115,7 +115,7 @@ FROM protoc-all AS prototool
 
 RUN wget -q -O /etc/apk/keys/sgerrand.rsa.pub https://alpine-pkgs.sgerrand.com/sgerrand.rsa.pub && \
     wget https://github.com/sgerrand/alpine-pkg-glibc/releases/download/2.31-r0/glibc-2.31-r0.apk && \
-    apk add glibc-2.31-r0.apk && \
+    apk add glibc-2.31-r0.apk || echo && \
     rm -f glibc-2.31-r0.apk
 
 ENTRYPOINT [ "prototool" ]

--- a/Dockerfile
+++ b/Dockerfile
@@ -112,6 +112,12 @@ ENTRYPOINT [ "protoc", "-I/opt/include" ]
 
 # prototool
 FROM protoc-all AS prototool
+
+RUN wget -q -O /etc/apk/keys/sgerrand.rsa.pub https://alpine-pkgs.sgerrand.com/sgerrand.rsa.pub && \
+    wget https://github.com/sgerrand/alpine-pkg-glibc/releases/download/2.31-r0/glibc-2.31-r0.apk && \
+    apk add glibc-2.31-r0.apk && \
+    rm -f glibc-2.31-r0.apk
+
 ENTRYPOINT [ "prototool" ]
 
 # grpc-cli


### PR DESCRIPTION
According to: https://github.com/uber/prototool/blob/dev/docs/faq.md#alpine-linux-issues

You need this version of glibc to run prototool otherwise it will simply output `exit 127`

```
bash-4.4# prototool compile
exit status 127
bash-4.4# wget -q -O /etc/apk/keys/sgerrand.rsa.pub https://alpine-pkgs.sgerrand.com/sgerrand.rsa.pub && \
>     wget https://github.com/sgerrand/alpine-pkg-glibc/releases/download/2.31-r0/glibc-2.31-r0.apk && \
>     apk add glibc-2.31-r0.apk && \
>     rm -f glibc-2.31-r0.apk
Connecting to github.com (140.82.118.3:443)
Connecting to github-production-release-asset-2e65be.s3.amazonaws.com (52.216.133.139:443)
glibc-2.31-r0.apk    100% |****************************************************************************************************************************************************************************************| 4308k  0:00:00 ETA
fetch http://dl-cdn.alpinelinux.org/alpine/v3.9/main/x86_64/APKINDEX.tar.gz
fetch http://dl-cdn.alpinelinux.org/alpine/v3.9/community/x86_64/APKINDEX.tar.gz
(1/1) Installing glibc (2.31-r0)
ERROR: glibc-2.31-r0: trying to overwrite lib64/ld-linux-x86-64.so.2 owned by libc6-compat-1.1.20-r5.
1 error; 73 MiB in 29 packages
bash-4.4# prototool compile
bash-4.4#
```