### PR TITLE
Support generate java-lite binding.

### DIFF
--- a/all/entrypoint.sh
+++ b/all/entrypoint.sh
@@ -55,7 +55,7 @@ GEN_PYI=false
 GEN_TYPESCRIPT=false
 LINT=false
 LINT_CHECKS=""
-SUPPORTED_LANGUAGES=("go" "ruby" "csharp" "java" "python" "objc" "gogo" "php" "node" "typescript" "web" "cpp" "descriptor_set" "scala")
+SUPPORTED_LANGUAGES=("go" "ruby" "csharp" "java" "python" "objc" "gogo" "php" "node" "typescript" "web" "cpp" "descriptor_set" "scala" "javalite")
 EXTRA_INCLUDES=""
 OUT_DIR=""
 GO_SOURCE_RELATIVE=""
@@ -363,6 +363,9 @@ Mgoogle/protobuf/field_mask.proto=github.com/gogo/protobuf/types,\
 ${GO_PACKAGE_MAP}\
 plugins=grpc+embedded\
 :$OUT_DIR"
+        ;;
+    "javalite")
+        GEN_STRING="--grpc_out=lite:$OUT_DIR --java_out=lite:$OUT_DIR --plugin=protoc-gen-grpc=$(which grpc_java_plugin)"
         ;;
     "java")
         GEN_STRING="--grpc_out=$OUT_DIR --${GEN_LANG}_out=$OUT_DIR --plugin=protoc-gen-grpc=$(which grpc_java_plugin)"


### PR DESCRIPTION
The java lite runtime has a much smaller code size which makes it more suitable to be used on Android. and it also works better with Proguard because it doesn’t rely on Java reflection and is optimized to allow as much code stripping as possible.

The support for javalite is very simple, just add "lite:" prefix to grpc_out and java_out, please kindly to accept this PR, thanks.