### PR TITLE
Fix base alpine image tag mismatch

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -73,7 +73,7 @@ RUN curl -sSL https://github.com/grpc/grpc-web/releases/download/${grpc_web}/pro
     -o /tmp/grpc_web_plugin && \
     chmod +x /tmp/grpc_web_plugin
 
-FROM alpine:3.9 AS protoc-all
+FROM alpine:$alpine AS protoc-all
 
 RUN set -ex && apk --update --no-cache add \
     bash \


### PR DESCRIPTION
"build" container uses alpine tag specified as $alpine ARG, but protoc-all, which is base image of grpc-cli, uses static tag 3.9.
This causes mismatch of C++ dynamic libraries like this:

> docker run namely/grpc-cli:latest
Error relocating /usr/local/bin/grpc_cli: _ZNSt7__cxx1119basic_ostringstreamIcSt11char_traitsIcESaIcEEC1Ev: symbol not found

This patch fixes Dockerfile to use the same alpine:$alpine for all base images.