### PR TITLE
Move from Swagger to OpenAPIv2

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -62,7 +62,7 @@ WORKDIR /tmp
 RUN go get -u google.golang.org/grpc
 
 RUN go get -u github.com/grpc-ecosystem/grpc-gateway/protoc-gen-grpc-gateway
-RUN go get -u github.com/grpc-ecosystem/grpc-gateway/protoc-gen-swagger
+RUN go get -u github.com/grpc-ecosystem/grpc-gateway/protoc-gen-openapiv2
 
 RUN go get -u github.com/gogo/protobuf/protoc-gen-gogo
 RUN go get -u github.com/gogo/protobuf/protoc-gen-gogofast
@@ -136,7 +136,7 @@ COPY --from=build /tmp/grpc_web_plugin /usr/local/bin/grpc_web_plugin
 
 COPY --from=build /tmp/protoc-gen-scala /usr/local/bin/
 
-COPY --from=build /go/src/github.com/grpc-ecosystem/grpc-gateway/protoc-gen-swagger/options/ /opt/include/protoc-gen-swagger/options/
+COPY --from=build /go/src/github.com/grpc-ecosystem/grpc-gateway/protoc-gen-openapiv2/options/ /opt/include/protoc-gen-openapiv2/options/
 
 COPY --from=build /go/src/github.com/envoyproxy/protoc-gen-validate/ /opt/include/
 COPY --from=build /go/src/github.com/mwitkow/go-proto-validators/ /opt/include/github.com/mwitkow/go-proto-validators/

--- a/all/entrypoint.sh
+++ b/all/entrypoint.sh
@@ -31,7 +31,9 @@ printUsage() {
     echo " --descr-filename               The filename for the descriptor proto when used with -l descriptor_set. Default to descriptor_set.pb"
     echo " --csharp_opt                   The options to pass to protoc to customize the csharp code generation."
     echo " --scala_opt                    The options to pass to protoc to customize the scala code generation."
-    echo " --with-swagger-json-names      Use with --with-gateway flag. Generated swagger file will use JSON names instead of protobuf names."
+    echo " --with-swagger-json-names      Use with --with-gateway flag. Generated swagger file will use JSON names instead of protobuf names.
+                                             (deprecated. Please use --with-openapi-json-names)"
+    echo " --with-openapi-json-names      Use with --with-gateway flag. Generated OpenAPI file will use JSON names instead of protobuf names."
 }
 
 
@@ -57,7 +59,7 @@ DESCR_INCLUDE_SOURCE_INFO=false
 DESCR_FILENAME="descriptor_set.pb"
 CSHARP_OPT=""
 SCALA_OPT=""
-SWAGGER_JSON=false
+OPENAPI_JSON=false
 
 while test $# -gt 0; do
     case "$1" in
@@ -182,7 +184,11 @@ while test $# -gt 0; do
             shift
             ;;
         --with-swagger-json-names)
-            SWAGGER_JSON=true
+            OPENAPI_JSON=true
+            shift
+            ;;
+        --with-openapi-json-names)
+            OPENAPI_JSON=true
             shift
             ;;
         *)
@@ -412,11 +418,11 @@ if [ $GEN_GATEWAY = true ]; then
     protoc $PROTO_INCLUDE \
 		--grpc-gateway_out=logtostderr=true:$GATEWAY_DIR ${PROTO_FILES[@]}
 
-    if [[ $SWAGGER_JSON == true ]]; then
+    if [[ $OPENAPI_JSON == true ]]; then
         protoc $PROTO_INCLUDE  \
-		    --swagger_out=logtostderr=true,json_names_for_fields=true:$GATEWAY_DIR ${PROTO_FILES[@]}
+		    --openapiv2_out=logtostderr=true,json_names_for_fields=true:$GATEWAY_DIR ${PROTO_FILES[@]}
     else
         protoc $PROTO_INCLUDE  \
-		    --swagger_out=logtostderr=true:$GATEWAY_DIR ${PROTO_FILES[@]}
+		    --openapiv2_out=logtostderr=true:$GATEWAY_DIR ${PROTO_FILES[@]}
     fi
 fi

--- a/build.sh
+++ b/build.sh
@@ -5,7 +5,7 @@ source ./variables.sh
 for build in ${BUILDS[@]}; do
     tag=${CONTAINER}/${build}:${GRPC_VERSION}_${BUILD_VERSION}
     echo "building ${build} container with tag ${tag}"
-	docker build -t ${tag} \
+    podman build -t ${tag} \
         -f Dockerfile \
         --build-arg grpc_version=${GRPC_VERSION} \
         --build-arg grpc_java_version=${GRPC_JAVA_VERSION} \
@@ -16,6 +16,6 @@ for build in ${BUILDS[@]}; do
 
     if [ "${LATEST}" = true ]; then
         echo "setting ${tag} to latest"
-        docker tag ${tag} ${CONTAINER}/${build}:latest
+        podman tag ${tag} ${CONTAINER}/${build}:latest
     fi
 done

--- a/build.sh
+++ b/build.sh
@@ -5,7 +5,7 @@ source ./variables.sh
 for build in ${BUILDS[@]}; do
     tag=${CONTAINER}/${build}:${GRPC_VERSION}_${BUILD_VERSION}
     echo "building ${build} container with tag ${tag}"
-    podman build -t ${tag} \
+    docker build -t ${tag} \
         -f Dockerfile \
         --build-arg grpc_version=${GRPC_VERSION} \
         --build-arg grpc_java_version=${GRPC_JAVA_VERSION} \
@@ -16,6 +16,6 @@ for build in ${BUILDS[@]}; do
 
     if [ "${LATEST}" = true ]; then
         echo "setting ${tag} to latest"
-        podman tag ${tag} ${CONTAINER}/${build}:latest
+        docker tag ${tag} ${CONTAINER}/${build}:latest
     fi
 done

--- a/cli/entrypoint.sh
+++ b/cli/entrypoint.sh
@@ -9,6 +9,6 @@ set -e
 
 ln -sf /defs/* /run/
 ln -sf /opt/include/google /run/
-ln -sf /opt/include/protoc-gen-swagger /run/
+ln -sf /opt/include/protoc-gen-openapiv2 /run/
 
 grpc_cli "$@"


### PR DESCRIPTION
The Swagger module is not available anymore and has been substitute by the OpenAPIv2 one.
This is also fixing the build that is failing at the moment.

See https://github.com/grpc-ecosystem/grpc-gateway/commit/58213a464a0f1368ec047b870c33a4a16e0ccf90