### PR TITLE
Fix build due to unpinned mismatched version of protoc-gen-doc

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -70,7 +70,8 @@ RUN ( cd ./grpc-go/cmd/protoc-gen-go-grpc && go install . )
 
 # Go get go-related bins
 WORKDIR /tmp
-RUN go get -u google.golang.org/grpc
+RUN set -e && \
+    GO111MODULE=on go get google.golang.org/grpc@v$grpc_version
 
 # install protoc-gen-grpc-gateway and protoc-gen-openapiv2
 RUN set -e && \
@@ -87,7 +88,9 @@ RUN go get -u github.com/gogo/protobuf/protoc-gen-gogo
 RUN go get -u github.com/gogo/protobuf/protoc-gen-gogofast
 
 RUN go get -u github.com/ckaznocha/protoc-gen-lint
-RUN go get -u github.com/pseudomuto/protoc-gen-doc/cmd/protoc-gen-doc
+
+RUN set -e && \
+    GO111MODULE=on go get github.com/pseudomuto/protoc-gen-doc/cmd/protoc-gen-doc
 
 RUN go get -u github.com/micro/micro/cmd/protoc-gen-micro
 

--- a/all/test.sh
+++ b/all/test.sh
@@ -130,6 +130,17 @@ testGeneration() {
         fi
     fi
 
+    if [[ "$extra_args" == *"--with-docs"* ]]; then
+        expected_file_name="/doc/index.html"
+        if [[ "$extra_args" == *"markdown,index.md"* ]]; then
+            expected_file_name="/doc/index.md"
+        fi
+        if [[ ! -f "$expected_output_dir$expected_file_name" ]]; then
+            echo "$expected_file_name file was not generated in $expected_output_dir"
+            exit 1
+        fi
+    fi
+
         # Test that we have generated the test.pb.go file.
         expected_file_name="/all/test.pb.go"
     if [[ "$extra_args" == *"--with-validator"* ]]; then
@@ -201,6 +212,10 @@ testGeneration() {
     rm -rf `echo $expected_output_dir | cut -d '/' -f1`
     echo "Generating for $lang passed!"
 }
+
+# Test docs generation
+testGeneration go "gen/pb-go" 0 --with-docs
+testGeneration go "gen/pb-go" 0 --with-docs markdown,index.md
 
 # Test grpc-gateway generation (only valid for Go)
 testGeneration go "gen/pb-go" 0 --with-gateway


### PR DESCRIPTION
 - The build was failing because of an upgrade to protoc-gen-doc that is not compatible.
To solve the problem the protoc-gen-doc module was pinned to the latest version that is compatible.
 - Also:
 -     Added tests for the relevant flag option
 -     Pinned Golang grpc module to match the image's version.