### PR TITLE
add "native" typescript support

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -123,7 +123,7 @@ RUN curl -sSL https://github.com/grpc/grpc-web/releases/download/${grpc_web_vers
     
 # Add Typescript support
 RUN npm --global config set user root
-RUN npm --global install protoc-gen-ts
+RUN npm --global install google-protobuf typescript protoc-gen-ts
 
 FROM debian:$debian-slim AS protoc-all
 
@@ -172,7 +172,8 @@ COPY --from=build /tmp/grpc-java/bazel-bin/compiler/ /usr/local/bin/
 # Copy grpc_cli
 COPY --from=build /tmp/grpc/bazel-bin/test/cpp/util/ /usr/local/bin/
 # Copy protoc-gen-ts
-COPY --from=build /usr/local/lib/node_modules /usr/local/lib/node_modules
+COPY --from=build /usr/lib/node_modules /usr/lib/node_modules
+COPY --from=build /usr/bin/protoc-gen-ts /usr/bin/protoc-gen-ts
 
 COPY --from=build /usr/local/bin/prototool /usr/local/bin/prototool
 COPY --from=build /go/bin/* /usr/local/bin/

--- a/Dockerfile
+++ b/Dockerfile
@@ -120,6 +120,10 @@ RUN curl -LO https://github.com/scalapb/ScalaPB/releases/download/v${scala_pb_ve
 RUN curl -sSL https://github.com/grpc/grpc-web/releases/download/${grpc_web_version}/protoc-gen-grpc-web-${grpc_web_version}-linux-x86_64 \
     -o /tmp/grpc_web_plugin && \
     chmod +x /tmp/grpc_web_plugin
+    
+# Add Typescript support
+RUN npm --global config set user root
+RUN npm --global install protoc-gen-ts
 
 FROM debian:$debian-slim AS protoc-all
 
@@ -167,6 +171,8 @@ COPY --from=build /tmp/grpc/bazel-bin/src/compiler/ /usr/local/bin/
 COPY --from=build /tmp/grpc-java/bazel-bin/compiler/ /usr/local/bin/
 # Copy grpc_cli
 COPY --from=build /tmp/grpc/bazel-bin/test/cpp/util/ /usr/local/bin/
+# Copy protoc-gen-ts
+COPY --from=build /usr/local/lib/node_modules /usr/local/lib/node_modules
 
 COPY --from=build /usr/local/bin/prototool /usr/local/bin/prototool
 COPY --from=build /go/bin/* /usr/local/bin/

--- a/all/entrypoint.sh
+++ b/all/entrypoint.sh
@@ -37,6 +37,7 @@ printUsage() {
     echo " --with-openapi-json-names      Use with --with-gateway flag. Generated OpenAPI file will use JSON names instead of protobuf names."
     echo " --generate-unbound-methods     Use with --with-gateway flag. Produce the HTTP mapping even for methods without any HttpRule annotation."
     echo " --js-out                       This option overrides the 'js_out=' argument in the grpc-node and grpc-web code generation. Defaults to 'import_style=commonjs'."
+    echo " --ts-out                       This option overrides the 'ts_out=' argument in the grpc-typescript code generation."
     echo " --grpc-out                     This option allows overriding the left-half of the 'grpc_out=' argument (before the colon) with grpc-node and grpc-web code generation. Options are: generate_package_definition, grpc_js or grpc(depricated from April 2021). Defaults to grpc_js."
     echo " --grpc-web-out                 This option overrides the 'grpc-web_out=' argument in the grpc-web code generation.  Defaults to 'import_style=typescript'."
 }
@@ -50,7 +51,7 @@ GEN_RBI=false
 GEN_TYPESCRIPT=false
 LINT=false
 LINT_CHECKS=""
-SUPPORTED_LANGUAGES=("go" "ruby" "csharp" "java" "python" "objc" "gogo" "php" "node" "web" "cpp" "descriptor_set" "scala")
+SUPPORTED_LANGUAGES=("go" "ruby" "csharp" "java" "python" "objc" "gogo" "php" "node" "web" "typescript" "cpp" "descriptor_set" "scala")
 EXTRA_INCLUDES=""
 OUT_DIR=""
 GO_SOURCE_RELATIVE=""
@@ -218,6 +219,11 @@ while test $# -gt 0; do
             JS_OUT=$1
             shift
             ;;
+        --ts-out)
+            shift
+            TS_OUT=$1
+            shift
+            ;;
         --grpc-web-out)
             shift
             WEB_OUT=$1
@@ -359,6 +365,10 @@ plugins=grpc+embedded\
         # add plugins
         GEN_STRING=" --plugin=protoc-gen-grpc-web=`which protoc-gen-grpc-web`"
         GEN_STRING="$GEN_STRING --js_out=$JS_OUT,binary:$OUT_DIR --grpc-web_out=$WEB_OUT,mode=grpcwebtext:$OUT_DIR"
+        ;;
+    "typescript")
+	# NOTE - It seems that the plugin has no support for any options besides the output directory, the value of --ts-out is still stored in $TS_OUT just in case we need it
+        GEN_STRING="--ts_out=$OUT_DIR"
         ;;
     "descriptor_set")
         GEN_STRING="--descriptor_set_out=$OUT_DIR/$DESCR_FILENAME"

--- a/all/entrypoint.sh
+++ b/all/entrypoint.sh
@@ -68,6 +68,7 @@ SCALA_OPT=""
 OPENAPI_JSON=false
 GENERATE_UNBOUND_METHODS=false
 JS_OUT="import_style=commonjs"
+TS_OUT=""
 WEB_OUT="import_style=typescript"
 GRPC_OUT="grpc_js"
 while test $# -gt 0; do


### PR DESCRIPTION
I wish to add proper typescript support to the container via the protoc-gen-ts plugin (the code js_out produces is from the previous century).

At first I started to add this module in a custom dockerfile that extends from this one, but I quickly realized that most of the "magic" is done in this shell script.

So in order to help everyone and not just myself I made this PR. I am super new to Docker and also not very experienced with shell scripting, so any help is more than welcome :D