### PR TITLE
[PG-3] Add Codacy badges to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,7 @@
 # gRPC/Protocol Buffer Compiler Containers
+ 
+[![Codacy Badge](https://app.codacy.com/project/badge/Grade/e20c6e95969a4926abd1dc778e8c8e7e)](https://app.codacy.com/gh/namely/docker-protoc/dashboard)
+[![Codacy Badge](https://app.codacy.com/project/badge/Coverage/e20c6e95969a4926abd1dc778e8c8e7e)](https://app.codacy.com/gh/namely/docker-protoc/dashboard)
 
 [![GitHub Workflow Status (branch)](https://github.com/namely/docker-protoc/actions/workflows/master.yml/badge.svg)](https://github.com/namely/docker-protoc/actions?query=workflow%3AMaster)
 [![Docker Pulls](https://img.shields.io/docker/pulls/namely/protoc-all?style=flat-square)](https://hub.docker.com/repository/docker/namely/protoc-all)


### PR DESCRIPTION

# What does this do?

This PR adds the Codacy badges to the README.md

# Why are we doing this?

The Codacy badges provide an easy at-a-glance view of the code quality and coverage for the repository and increase awareness of quality goals.

Please drop in on the #codacy-discussion channel in Slack if you have any questions.