### PR TITLE
Configure automatic grpc releases

### DIFF
--- a/.github/workflows/grpc_release.yml
+++ b/.github/workflows/grpc_release.yml
@@ -1,0 +1,44 @@
+# This worklow will create a new GH release according to the current GRPC_VERSION value in variables.sh
+# It is triggered after a PR from head "renovate/grpc-major-upgrade" is merged to master.
+
+# 'renovate/grpc-major-upgrade' is a branch created by Renovate when it finds a new gRPC version to update in variables.sh
+# Renovate with this worflow allows us to automatically create new releases whenever Google releases a new gRPC version in github.com/grpc/grpc
+
+# All new versions created by this worflow will be suffixed by _0, e.g v1.46_0. At the moment, patches unrelated to the gRPC version (e.g v1.46_1)
+# will still be released manually (for now).
+
+# Note that once a new release is created in GH, a separate workflow will take care of releasing new docker images to dockerhub accordingly.
+
+name: New gPRC Release
+
+on:
+  pull_request:
+    types:
+      - closed
+    branches:    
+      - 'master'
+
+jobs:
+  new_release:
+    if: github.event.pull_request.merged == true && github.head_ref == 'renovate/grpc-major-upgrade'
+    runs-on: ubuntu-latest
+    steps:
+    # checkout the repo
+      - uses: actions/checkout@v2
+        with:
+          submodules: true
+    # install pcregrep to help extrat the version from variables.sh
+      - name: Install pcregrep
+        run: sudo sudo apt-get update -y && sudo apt-get install -y pcregrep
+      - name: Get version name
+        run: |
+          VER=$(pcregrep -o1 "^GRPC_VERSION=\\$\{GRPC_VERSION:-(.*?)\\}$" variables.sh)
+          # This makes the value accessible from env.Version
+          echo "VERSION=v${VER}_0" >> $GITHUB_ENV
+      - name: Create new release
+        if: success()
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run:
+          gh release create ${{ env.VERSION }} --generate-notes --repo $GITHUB_REPOSITORY
+          

--- a/README.md
+++ b/README.md
@@ -289,7 +289,8 @@ CONTAINER=namely/gen-grpc-gateway:VVV make test-gwy
 
 ### Release
 
-Handled automatically via CI (githubaction).
+Any new gRPC version based release is handled automatically once the relevant [Renovate](https://www.mend.io/free-developer-tools/renovate/) branch is merged to master
+via the CI (Github Action). A patch release should be created manually in Github and the CI workflow will take care of the rest.
 
 #### Contributors
 


### PR DESCRIPTION
With this change, a new GH release will be created automatically every time we merge a Renovate branch which updated the gRPC version to master.

The branch name is determined in the Renovate configuration file and is referenced in the GH Action workflow file in this PR, so that other type of PRs whether they are created by the Renovate user or any other user, will be ignored.

This will allow us to avoid creating a new release manually after merging.
If and when we automerge the Renovate PRs, the process will be fully automated, i.e every time a new gRPC version is released to github.com/grpc/grpc, the matching docker images artifacts of this repo will be released as well.