### PR TITLE
Generate gateway files according to source-relative flag

### DIFF
--- a/all/entrypoint.sh
+++ b/all/entrypoint.sh
@@ -483,7 +483,7 @@ if [ $GEN_GATEWAY = true ]; then
     mkdir -p ${GATEWAY_DIR}
 
     protoc $PROTO_INCLUDE \
-        --grpc-gateway_out=logtostderr=true:$GATEWAY_DIR ${PROTO_FILES[@]} \
+        --grpc-gateway_out=${GO_SOURCE_RELATIVE}logtostderr=true:$GATEWAY_DIR ${PROTO_FILES[@]} \
         --grpc-gateway_opt generate_unbound_methods=$GENERATE_UNBOUND_METHODS
 
     if [[ $OPENAPI_JSON == true ]]; then

--- a/all/test/all_test.go
+++ b/all/test/all_test.go
@@ -616,7 +616,7 @@ func (s *TestSuite) TestAllCases() {
 	src := path.Join(wd, "all")
 	for name, testCase := range testCases {
 		s.Run(name, func() {
-			// s.T().Parallel()
+			s.T().Parallel()
 			dir, err := ioutil.TempDir(wd, testCase.lang)
 			defer os.RemoveAll(dir)
 			s.Require().NoError(err)

--- a/all/test/all_test.go
+++ b/all/test/all_test.go
@@ -326,6 +326,21 @@ func (s *TestSuite) TestAllCases() {
 			},
 			extraArgs: []string{"--with-gateway"},
 		},
+		"go with gateway and source_relative": {
+			lang:              "go",
+			protofileName:     "all/test/test.proto",
+			expectedOutputDir: "gen/pb-go",
+			fileExpectations: []FileExpectation{
+				{fileName: "all/test/test.pb.go"},
+				{fileName: "/all/test/test.pb.gw.go", assert: func(filePath, expectedValue string) {
+					fileText := s.readFile(filePath)
+					s.Assert().False(strings.Contains(fileText, expectedValue), "contains \"%s\"", expectedValue)
+				}, expectedValue: "UnboundUnary",
+				},
+				{fileName: "/all/test/test.swagger.json"},
+			},
+			extraArgs: []string{"--with-gateway", "--go-source-relative"},
+		},
 		"go with gateway and json": {
 			lang:              "go",
 			protofileName:     "all/test/test.proto",
@@ -553,16 +568,16 @@ func (s *TestSuite) TestAllCases() {
 			extraArgs: []string{"--with-validator"},
 		},
 		"typescript": {
-			lang: "typescript",
-			protofileName: "all/test/test.proto",
+			lang:              "typescript",
+			protofileName:     "all/test/test.proto",
 			expectedOutputDir: "gen/pb-typescript",
 			fileExpectations: []FileExpectation{
 				{fileName: "all/test/test.ts"},
 			},
 		},
 		"typescript with alternative output dir": {
-			lang: "typescript",
-			protofileName: "all/test/test.proto",
+			lang:              "typescript",
+			protofileName:     "all/test/test.proto",
 			expectedOutputDir: "gen/foo/bar",
 			fileExpectations: []FileExpectation{
 				{fileName: "all/test/test.ts", assert: func(filePath, expectedValue string) {
@@ -574,8 +589,8 @@ func (s *TestSuite) TestAllCases() {
 			extraArgs: []string{"-o", "gen/foo/bar"},
 		},
 		"typescript with arguments": {
-			lang: "typescript",
-			protofileName: "all/test/test.proto",
+			lang:              "typescript",
+			protofileName:     "all/test/test.proto",
 			expectedOutputDir: "gen/pb-typescript",
 			fileExpectations: []FileExpectation{
 				{fileName: "all/test/test.ts", assert: func(filePath, expectedValue string) {
@@ -601,7 +616,7 @@ func (s *TestSuite) TestAllCases() {
 	src := path.Join(wd, "all")
 	for name, testCase := range testCases {
 		s.Run(name, func() {
-			s.T().Parallel()
+			// s.T().Parallel()
 			dir, err := ioutil.TempDir(wd, testCase.lang)
 			defer os.RemoveAll(dir)
 			s.Require().NoError(err)


### PR DESCRIPTION
Ensure the gateway files are generated according the source_relative settings.
Credit to @vaijab