### PR TITLE
Update where Renovate updates the Go version

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -153,6 +153,19 @@
       ],
       depNameTemplate: "google.golang.org/grpc/cmd/protoc-gen-go-grpc",
       datasourceTemplate: "go",
+    },
+    {
+      fileMatch: [
+        "variables.sh$", 
+        ".github/renovate.json5$"
+      ],
+      matchStrings: [
+        "GO_VERSION=\\$\\{GO_VERSION:-(?<currentValue>.*?)\\}\\n", 
+        "constraints: {(\\s*\\n\\s*)\"go\":\\s*\"(?<currentValue>.*?)\""
+      ],
+      depNameTemplate: "go",
+      datasourceTemplate: "golang-version",
+      versioningTemplate: "npm",
     }
   ],
   packageRules: [


### PR DESCRIPTION
This PR will modify https://github.com/namely/docker-protoc/pull/319 (and others like it in the future),
so that it will also update the Go version [here](https://github.com/namely/docker-protoc/blob/master/variables.sh#L9) and [here](https://github.com/namely/docker-protoc/blob/master/.github/renovate.json5#L8).