### PR TITLE
Renovate  - update the Go version in one more location

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -147,11 +147,13 @@
     {
       fileMatch: [
         "variables.sh$", 
-        ".github/renovate.json5$"
+        ".github/renovate.json5$",
+        "gwy/templates/Dockerfile.tmpl$"
       ],
       matchStrings: [
-        "GO_VERSION=\\$\\{GO_VERSION:-(?<currentValue>.*?)\\}\\n", 
-        "constraints: {(\\s*\\n\\s*)\"go\":\\s*\"(?<currentValue>.*?)\""
+        "GO_VERSION=\\$\\{GO_VERSION:-(?<currentValue>.*?)\\}\\n",
+        "constraints: {(\\s*\\n\\s*)\"go\":\\s*\"(?<currentValue>.*?)\"",
+        "ARG go_version=(?<currentValue>.*?)"
       ],
       depNameTemplate: "go",
       datasourceTemplate: "golang-version",


### PR DESCRIPTION
Forgot one more location the Go version should be updated - 
https://github.com/namely/docker-protoc/blob/master/gwy/templates/Dockerfile.tmpl#L4