### PR TITLE
Fix the Renovate regex for the go upgrade

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -153,7 +153,7 @@
       matchStrings: [
         "GO_VERSION=\\$\\{GO_VERSION:-(?<currentValue>.*?)\\}\\n",
         "constraints: {(\\s*\\n\\s*)\"go\":\\s*\"(?<currentValue>.*?)\"",
-        "ARG go_version=(?<currentValue>.*?)"
+        "ARG go_version=(?<currentValue>.*?)\\n"
       ],
       depNameTemplate: "go",
       datasourceTemplate: "golang-version",


### PR DESCRIPTION
The regex in the previous PR was not accurate.
This one works though - tested on my fork https://github.com/ido-namely/docker-protoc/pull/27/files#diff-842c17f24ff78272657d7c5ae75b4bde7c83c0064d9a5efccac10a1a0feeeb10