### PR TITLE
Remove potential leading colon from PYTHONPATH

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -190,7 +190,7 @@ COPY --from=build /go/pkg/mod/github.com/mwitkow/go-proto-validators@v${go_mwitk
 # Copy mypy
 COPY --from=build /opt/mypy-protobuf/ /opt/mypy-protobuf/
 RUN mv /opt/mypy-protobuf/bin/* /usr/local/bin/
-ENV PYTHONPATH="${PYTHONPATH}:/opt/mypy-protobuf/"
+ENV PYTHONPATH="${PYTHONPATH:+$PYTHONPATH:}/opt/mypy-protobuf/"
 
 ADD all/entrypoint.sh /usr/local/bin
 RUN chmod +x /usr/local/bin/entrypoint.sh

--- a/all/test/all_test.go
+++ b/all/test/all_test.go
@@ -688,6 +688,17 @@ func (s *TestSuite) TestAllCases() {
 				defer os.RemoveAll(dir)
 				s.Require().NoError(err)
 				err = copy.Copy(src, path.Join(dir, "all"), opt)
+
+				// We previously had a buggy PYTHONPATH which would search the working directory for
+				// modules when running the Python generator.
+				//
+				// Let's add something that with the same name as a standard library module to the test
+				// directory as a regression test.
+				//
+				// Further context: https://github.com/namely/docker-protoc/pull/356
+				_, err = os.OpenFile(path.Join(dir, "io.py"), os.O_RDONLY|os.O_CREATE, 0666)
+				s.Require().NoError(err)
+
 				argsStr := fmt.Sprintf(DockerCmd,
 					dir,
 					container,


### PR DESCRIPTION
When PYTHONPATH is empty to start with, it gets set to a value of `:/opt/mypy-protobuf/`. The leading semicolon acts as an empty entry at the beginning of the path list and implies the current working directory. So this can break Python plugins depending on what directory `protoc` is executed in. I've got a snippet below to demonstrate what I mean.

```console
// Printing the default PYTHONPATH, notice the leading semicolon.
tetsuo@Alexs-MacBook-Pro protobuf-specs % docker run --platform linux/amd64 -v ${PWD}:/defs --entrypoint bash namely/protoc-all:latest -c 'echo "$PYTHONPATH"'
:/opt/mypy-protobuf/

// Now do a simple print via the Python interpreter.
tetsuo@Alexs-MacBook-Pro protobuf-specs % docker run --platform linux/amd64 -v ${PWD}:/defs --entrypoint python3 namely/protoc-all:latest -c "print('Hello, World!')"
Hello, World!

// Create a Python module in the current working directory called io.
tetsuo@Alexs-MacBook-Pro protobuf-specs % touch io.py

// Because of the empty entry at the beginning of the PYTHONPATH, the interpreter tries to import this empty Python module thinking that it's the standard library module of the same name.
tetsuo@Alexs-MacBook-Pro protobuf-specs % docker run --platform linux/amd64 -v ${PWD}:/defs --entrypoint python3 namely/protoc-all:latest -c "print('Hello, World!')"
Fatal Python error: init_sys_streams: can't initialize sys standard streams
Python runtime state: core initialized
AttributeError: module 'io' has no attribute 'open'

Current thread 0x0000004000bc9980 (most recent call first):
<no Python frame>

// If we fix the PYTHONPATH with the -e flag to Docker, this fixes the issue.
tetsuo@Alexs-MacBook-Pro protobuf-specs % docker run --platform linux/amd64 -v ${PWD}:/defs --entrypoint python3 -e PYTHONPATH="/opt/mypy-protobuf/" namely/protoc-all:latest -c "print('Hello, World!')"
Hello, World!
```

Just fyi, I haven't been able to build the `protoc-all` container on my machine yet as I'm hitting an unrelated build issue. I'll try to get to that and test this change when I can.

CC: @ido-namely 