### PR TITLE
Remove xargs warning for Python generation

### DIFF
--- a/all/entrypoint.sh
+++ b/all/entrypoint.sh
@@ -492,7 +492,7 @@ protoc $PROTO_INCLUDE \
 if [[ $GEN_LANG == "python" ]]; then
     # Create __init__.py for everything in the OUT_DIR
     # (i.e. gen/pb_python/foo/bar/).
-    find $OUT_DIR -type d | xargs -n1 -I '{}' touch '{}/__init__.py'
+    find $OUT_DIR -type d | xargs -I '{}' touch '{}/__init__.py'
     # And everything above it (i.e. gen/__init__py")
     d=`dirname $OUT_DIR`
     while [[ "$d" != "." && "$d" != "/" ]]; do


### PR DESCRIPTION
There is a warning when running with `-l python`:
```
$ docker run -v $PWD:/defs namely/protoc-all:1.51_2 -l python -d /defs
xargs: warning: options --max-args and --replace/-I/-i are mutually exclusive, ignoring previous --max-args value
```
Hence we can remove the `--max-args` a.k.a. `-n` option.